### PR TITLE
Autofocus bugfix

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "ScorePad with Rounds",
     "slug": "scorepad",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "updates": {

--- a/src/screens/ConfigureScreen.js
+++ b/src/screens/ConfigureScreen.js
@@ -15,7 +15,7 @@ const ConfigureScreen = () => {
 
     const setPlayerNameHandler = (index, name) => {
         dispatch(setPlayerName(index, name));
-        setPlayerWasAdded(true)
+        setPlayerWasAdded(false)
     }
 
     const newGameHandler = () => {


### PR DESCRIPTION
When adding a player, if you delete immediately, it will unset the name
of the newly last player. I wasn't resetting playerWasAdded to false.