### PR TITLE
Max height on configure infographic

### DIFF
--- a/src/screens/ConfigureScreen.js
+++ b/src/screens/ConfigureScreen.js
@@ -67,15 +67,13 @@ const ConfigureScreen = () => {
                     resizeMethod={'scale'}
                     alignSelf={'center'}
                     style={{
-                        width: Dimensions.get('window').width * .4,
-                        height: Dimensions.get('window').width * .4,
+                        width: Math.min(Dimensions.get('window').width * .4, Dimensions.get('window').height * .4),
+                        height: Math.min(Dimensions.get('window').width * .4, Dimensions.get('window').height * .4),
                         maxWidth: '50%',
                         aspectRatio: 1,
                         margin: 20,
                     }}
                 />
-                {/* <Text flex={1} style={styles.text}>Tap the top half of a player's card to add a point. Tap the bottom half to subtract.</Text> */}
-                {/* <Text flex={1} style={styles.text}>Tip: To add or subtract faster, try tapping with two alternating fingers.</Text> */}
 
                 <View style={{ margin: 10, }}>
                     <Button


### PR DESCRIPTION
## Overview

Set a max height so that in landscape mode, you can see more than just the infographic

## Screenshots

|Before|After|
|---|---|
|<img width="893" alt="image" src="https://user-images.githubusercontent.com/1986068/145935492-d87be598-115f-4fb1-89fb-4fe622d3609e.png">|<img width="893" alt="image" src="https://user-images.githubusercontent.com/1986068/145935510-ca54fdc1-b09e-48e2-953d-590668b356a2.png">|