### PR TITLE
Style cleanup

### DIFF
--- a/src/components/RoundTitle.js
+++ b/src/components/RoundTitle.js
@@ -47,12 +47,13 @@ function RoundTitle({ navigation }) {
                     style={{ justifyContent: 'center' }}
                     onPress={prevRoundHandler} >
                     <View>
-                        <Feather name="chevron-left" style={[styles.roundButton]} />
+                        <Icon name="chevron-left" type="font-awesome-5" size={25} color="#0a84ff" style={[styles.roundButton, { opacity: currentRound == 0 ? 0 : 1 }]} />
                     </View>
                 </TouchableOpacity>
 
                 <Text style={{
-                    fontSize: 25, color: 'white',
+                    fontSize: 25,
+                    color: 'white',
                     fontVariant: ['tabular-nums'],
                     fontWeight: 'bold'
                 }}>Round {currentRound + 1}</Text>
@@ -61,13 +62,13 @@ function RoundTitle({ navigation }) {
                     style={{ justifyContent: 'center', }}
                     onPress={nextRoundHandler} >
                     <View>
-                        <Feather name="chevron-right" style={[styles.roundButton]} />
+                        <Icon name="chevron-right" type="font-awesome-5" size={25} color="#0a84ff" style={[styles.roundButton]} />
                     </View>
                 </TouchableOpacity>
 
             </View>
             <SafeAreaView edges={['right']}>
-                <Icon fontSize={25} name={expanded ? 'expand-alt' : 'compress-alt'} color="#0a84ff" type="font-awesome-5" onPress={expandHandler} ></Icon>
+                <Icon size={25} name={expanded ? 'expand-alt' : 'compress-alt'} color="#0a84ff" type="font-awesome-5" onPress={expandHandler} />
             </SafeAreaView>
         </SafeAreaView>
     );
@@ -85,12 +86,13 @@ const styles = StyleSheet.create({
     multiplier: {
         color: '#0a84ff',
         paddingHorizontal: 5,
-        fontSize: 22,
+        fontSize: 25,
         fontWeight: 'bold',
         fontVariant: ['tabular-nums'],
     },
     roundButton: {
-        fontSize: 35,
+        fontSize: 25,
+        paddingHorizontal: 10,
         fontWeight: 'bold',
         color: '#0a84ff',
     },

--- a/src/components/Rounds.js
+++ b/src/components/Rounds.js
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Text, View, StyleSheet, TouchableOpacity, ScrollView, Platform } from 'react-native';
 import { s, vs, ms, mvs } from 'react-native-size-matters';
+import { Icon } from 'react-native-elements/dist/icons/Icon';
 
 import { useSelector, useDispatch } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
-
-import { EvilIcons } from '@expo/vector-icons';
 
 function Rounds({ navigation, show }) {
     const palette = ["01497c", "c25858", "f5c800", "275436", "dc902c", "62516a", "755647", "925561"];
@@ -45,11 +44,11 @@ function Rounds({ navigation, show }) {
             </View>
 
             <View key={'total'} style={{ padding: 10 }}>
-                <Text style={[styles.sumHeader]}>
+                <Text style={[styles.totalHeader]}>
                     Total
                 </Text>
                 {players.map((player, playerIndex) => (
-                    <Text key={playerIndex} style={[styles.scoreEntry, { color: '#0a84ff' }]} >
+                    <Text key={playerIndex} style={[styles.scoreEntry, { color: 'white', fontWeight: 'bold' }]} >
                         {scores[playerIndex].reduce(
                             (a, b) => { return (a || 0) + (b || 0); }
                         )}
@@ -82,10 +81,11 @@ function Rounds({ navigation, show }) {
                 ))}
             </ScrollView>
 
-            <View style={{ flexDirection: 'column', justifyContent: 'space-around' }}>
+            <View style={{ flexDirection: 'column', justifyContent: 'space-around', padding: 10 }}>
                 <TouchableOpacity style={{ justifyContent: 'center' }}
                     onPress={() => { navigation.navigate("Configure") }}>
-                    <EvilIcons style={{ fontSize: ms(40, .4), color: 'white', textAlign: 'center' }} name="gear" color="black" />
+                    <Icon size={ms(30, .4)} color='#0a84ff' style={{ textAlign: 'center' }} name="cog" type="font-awesome-5" />
+                    <Text style={{ color: '#0a84ff', fontWeight: 'bold' }}>Settings</Text>
                 </TouchableOpacity>
             </View>
         </SafeAreaView >
@@ -93,8 +93,8 @@ function Rounds({ navigation, show }) {
 }
 
 const styles = StyleSheet.create({
-    sumHeader: {
-        color: '#0a84ff',
+    totalHeader: {
+        color: 'white',
         fontWeight: 'bold',
         textAlign: 'center',
         fontSize: 20,


### PR DESCRIPTION
## Overview

- Aligned header by baseline and matching font sizes
- Replaced gear with Icon cog
- Preserved 'system blue' color for interactive elements

## Screenshots

|Before|After|
|---|---|
|<img width="510" alt="image" src="https://user-images.githubusercontent.com/1986068/145939509-c6a4770a-7a8a-4189-95dc-4aa5da9d30ce.png">|<img width="466" alt="image" src="https://user-images.githubusercontent.com/1986068/145939473-04f47726-45ec-4ec8-9934-4fb017aa64a2.png">|