### PR TITLE
Fix player button

### DIFF
--- a/src/components/ScoreLog/PlayerNameColumn.js
+++ b/src/components/ScoreLog/PlayerNameColumn.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { TouchableOpacity } from 'react-native';
 
 import { palette, systemBlue } from '../../constants';
 import { selectGameById } from '../../../redux/GamesSlice';


### PR DESCRIPTION
TouchableOpacity should be imported from 'react-native' not 'react-native-gesture-handler'. Otherwise, it won't work.