### PR TITLE
EAS build configuration - instance size

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -7,18 +7,18 @@
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
-        "resourceClass": "m1-medium"
+        "resourceClass": "m-medium"
       }
     },
     "preview": {
       "distribution": "internal",
       "ios": {
-        "resourceClass": "m1-medium"
+        "resourceClass": "m-medium"
       }
     },
     "production": {
       "ios": {
-        "resourceClass": "m1-medium"
+        "resourceClass": "m-medium"
       }
     }
   },


### PR DESCRIPTION
Update to generic `m-medium` instance sizes for mac m1/m2 build instances.