### PR TITLE
Scale again

### DIFF
--- a/src/components/PlayerTile.tsx
+++ b/src/components/PlayerTile.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { View, StyleSheet, LayoutChangeEvent, DimensionValue } from 'react-native';
+import React from 'react';
+import { View, StyleSheet, DimensionValue } from 'react-native';
 
 import AdditionTile from './PlayerTiles/AdditionTile/AdditionTile';
 import { selectGameById } from '../../redux/GamesSlice';
@@ -8,17 +8,28 @@ import { useAppSelector } from '../../redux/hooks';
 import { TouchSurface } from './PlayerTiles/AdditionTile/TouchSurface';
 
 interface Props {
+    index: number;
+    playerId: string;
     color: string;
     fontColor: string;
     cols: number;
     rows: number;
-    playerId: string;
-    index: number;
+    width: number;
+    height: number;
 }
 
-const PlayerTile: React.FunctionComponent<Props> = ({ color, fontColor, cols, rows, playerId, index }) => {
-    const [width, setWidth] = useState(0);
-    const [height, setHeight] = useState(0);
+const PlayerTile: React.FunctionComponent<Props> = ({
+    index,
+    color,
+    fontColor,
+    width,
+    height,
+    cols,
+    rows,
+    playerId
+}) => {
+    // Short circuit if width or height is not yet defined
+    if (!(width > 0 && height > 0)) return null;
 
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
     const currentGame = useAppSelector(state => selectGameById(state, currentGameId));
@@ -40,21 +51,14 @@ const PlayerTile: React.FunctionComponent<Props> = ({ color, fontColor, cols, ro
     const widthPerc: DimensionValue = `${(100 / cols)}%`;
     const heightPerc: DimensionValue = `${(100 / rows)}%`;
 
-    const layoutHandler = (e: LayoutChangeEvent) => {
-        const { width, height } = e.nativeEvent.layout;
-
-        setWidth(width);
-        setHeight(height);
-    };
+    if (Number.isNaN(width) || Number.isNaN(height)) return null;
 
     return (
-        <View onLayout={layoutHandler}
-            style={[
-                styles.playerCard,
-                { backgroundColor: color },
-                { width: widthPerc },
-                { height: heightPerc },
-            ]}>
+        <View style={[
+            styles.playerCard,
+            { backgroundColor: color },
+            { width: widthPerc },
+            { height: heightPerc },]}>
             <AdditionTile
                 totalScore={scoreTotal}
                 roundScore={scoreRound}
@@ -62,8 +66,7 @@ const PlayerTile: React.FunctionComponent<Props> = ({ color, fontColor, cols, ro
                 playerName={playerName}
                 maxWidth={width}
                 maxHeight={height}
-                index={index}
-            />
+                index={index} />
 
             <TouchSurface
                 scoreType='increment'

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { StyleSheet, LayoutChangeEvent } from 'react-native';
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
 import Animated, {
     useSharedValue,
     useAnimatedStyle,
@@ -17,8 +17,8 @@ interface Props {
     totalScore: number;
     roundScore: number;
     fontColor: string;
-    maxWidth: number;
-    maxHeight: number;
+    maxWidth: number | null;
+    maxHeight: number | null;
     index: number;
 }
 
@@ -31,9 +31,8 @@ const AdditionTile: React.FunctionComponent<Props> = ({
     maxHeight,
     index
 }) => {
-    // Tile width and height
-    const [tileWidth, setTileWidth] = useState(1);
-    const [tileHeight, setTileHeight] = useState(1);
+
+    if (maxWidth == null || maxHeight == null) return null;
 
     // Animation values
     const sharedScale = useSharedValue(1);
@@ -42,47 +41,15 @@ const AdditionTile: React.FunctionComponent<Props> = ({
     // Animation styles for resizing due to text changes
     const animatedStyles = useAnimatedStyle(() => {
         return {
-            transform: [{ scale: sharedScale.value }],
             opacity: sharedOpacity.value,
         };
     });
 
 
-    // Update tile width and height on layout change
-    const layoutHandler = (e: LayoutChangeEvent) => {
-        const { width, height } = e.nativeEvent.layout;
-        setTileHeight(height);
-        setTileWidth(width);
-    };
-
     useEffect(() => {
-        /*
-         * Calculate ratio of tile content to max width/height
-         * determined by the parent container
-         */
-        const horizontalScaleRatio = maxWidth / tileWidth;
-        const verticalScaleRatio = maxHeight / tileHeight;
-
-        // Allow for padding by not scaling to full width/height
-        const maxTileCoverage = 0.8; // 80%
-
-        const minimumScale = Math.min(
-            horizontalScaleRatio * maxTileCoverage,
-            verticalScaleRatio * maxTileCoverage
-        );
-
-        if (minimumScale > 0) {
-            sharedScale.value = withDelay(
-                animationDuration,
-                withTiming(
-                    minimumScale, { duration: animationDuration }
-                )
-            );
-        }
-
         // Delay opacity animation to allow for scale animation to finish
         // and to allow for the previous tile to finish animating for effect
-        const animationDelay = index * animationDuration / 2;
+        const animationDelay = (index + 1) * animationDuration / 2;
 
         sharedOpacity.value = withDelay(
             animationDelay,
@@ -91,9 +58,17 @@ const AdditionTile: React.FunctionComponent<Props> = ({
                 { duration: animationDuration * 2 }
             )
         );
-    });
+        return;
+    }, [
+        playerName,
+        totalScore,
+        roundScore,
+        maxWidth,
+        maxHeight,
+        sharedScale.value
+    ]);
 
-    const playerNameFontSize = calculateFontSize(maxWidth, playerName.length);
+    const playerNameFontSize = calculateFontSize(maxWidth);
 
     const containerWidth = Math.min(maxWidth, maxHeight);
 
@@ -103,7 +78,8 @@ const AdditionTile: React.FunctionComponent<Props> = ({
     };
 
     return (
-        <Animated.View style={[animatedStyles, { justifyContent: 'center' }]} onLayout={layoutHandler}>
+        <Animated.View style={[animatedStyles, { justifyContent: 'center' }]} //onLayout={layoutHandler}
+        >
             <Animated.Text style={[styles.name, dynamicPlayerStyles]} numberOfLines={1}>
                 {playerName}
             </Animated.Text>

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
@@ -68,9 +68,9 @@ const AdditionTile: React.FunctionComponent<Props> = ({
         sharedScale.value
     ]);
 
-    const playerNameFontSize = calculateFontSize(maxWidth);
-
     const containerWidth = Math.min(maxWidth, maxHeight);
+
+    const playerNameFontSize = calculateFontSize(maxWidth);
 
     const dynamicPlayerStyles = {
         fontSize: playerNameFontSize,

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
@@ -38,7 +38,9 @@ const AdditionTile: React.FunctionComponent<Props> = ({
     const sharedScale = useSharedValue(1);
     const sharedOpacity = useSharedValue(0);
 
-    // Animation styles for resizing due to text changes
+    /**
+     * Animation styles for resizing due to text changes
+     */
     const animatedStyles = useAnimatedStyle(() => {
         return {
             opacity: sharedOpacity.value,

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
@@ -78,8 +78,7 @@ const AdditionTile: React.FunctionComponent<Props> = ({
     };
 
     return (
-        <Animated.View style={[animatedStyles, { justifyContent: 'center' }]} //onLayout={layoutHandler}
-        >
+        <Animated.View style={[animatedStyles, { justifyContent: 'center' }]}>
             <Animated.Text style={[styles.name, dynamicPlayerStyles]} numberOfLines={1}>
                 {playerName}
             </Animated.Text>
@@ -87,7 +86,7 @@ const AdditionTile: React.FunctionComponent<Props> = ({
                 style={styles.scoreLineOne} >
                 <ScoreBefore containerWidth={containerWidth} roundScore={roundScore} totalScore={totalScore}
                     fontColor={fontColor} />
-                <ScoreRound containerWidth={containerWidth} roundScore={roundScore} totalScore={totalScore}
+                <ScoreRound containerWidth={containerWidth} roundScore={roundScore}
                     fontColor={fontColor} />
             </Animated.View>
             <ScoreAfter containerWidth={containerWidth} roundScore={roundScore} totalScore={totalScore}

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
@@ -70,7 +70,7 @@ const AdditionTile: React.FunctionComponent<Props> = ({
         sharedScale.value
     ]);
 
-    const containerWidth = Math.min(maxWidth, maxHeight);
+    const containerShortEdge = Math.min(maxWidth, maxHeight);
 
     const playerNameFontSize = calculateFontSize(maxWidth);
 
@@ -84,14 +84,15 @@ const AdditionTile: React.FunctionComponent<Props> = ({
             <Animated.Text style={[styles.name, dynamicPlayerStyles]} numberOfLines={1}>
                 {playerName}
             </Animated.Text>
-            <Animated.View
-                style={styles.scoreLineOne} >
-                <ScoreBefore containerWidth={containerWidth} roundScore={roundScore} totalScore={totalScore}
+
+            <Animated.View style={styles.scoreLineOne}>
+                <ScoreBefore containerWidth={containerShortEdge} roundScore={roundScore} totalScore={totalScore}
                     fontColor={fontColor} />
-                <ScoreRound containerWidth={containerWidth} roundScore={roundScore}
+                <ScoreRound containerWidth={containerShortEdge} roundScore={roundScore}
                     fontColor={fontColor} />
             </Animated.View>
-            <ScoreAfter containerWidth={containerWidth} roundScore={roundScore} totalScore={totalScore}
+
+            <ScoreAfter containerWidth={containerShortEdge} roundScore={roundScore} totalScore={totalScore}
                 fontColor={fontColor} />
         </Animated.View>
     );

--- a/src/components/PlayerTiles/AdditionTile/Helpers.ts
+++ b/src/components/PlayerTiles/AdditionTile/Helpers.ts
@@ -23,13 +23,13 @@ export const exitingAnimation = ZoomOut.duration(animationDuration);
 export const layoutAnimation = Layout.easing(Easing.ease).duration(animationDuration);
 
 /**
- * Calculates the font size based on the maximum width and length of the text.
+ * Calculates the font size based on the maximum width.
  * @param containerWidth The maximum width of the text.
- * @param stringLength The number of characters in the text.
  * @returns The calculated font size.
  */
-export const calculateFontSize = (containerWidth: number, stringLength: number) => {
-    const baseScale: number = Math.min(1 / stringLength * 200, 100);
+export const calculateFontSize = (containerWidth: number) => {
+    // const baseScale: number = Math.min(1 / stringLength * 200, 100);
+    const baseScale = 40;
 
     let widthFactor: number = containerWidth / 200;
 

--- a/src/components/PlayerTiles/AdditionTile/Helpers.ts
+++ b/src/components/PlayerTiles/AdditionTile/Helpers.ts
@@ -22,20 +22,23 @@ export const exitingAnimation = ZoomOut.duration(animationDuration);
  */
 export const layoutAnimation = Layout.easing(Easing.ease).duration(animationDuration);
 
+export const singleLineScoreSizeMultiplier = 1.2;
+
+export const multiLineScoreSizeMultiplier = 0.7;
+
+export const baseScoreFontSize = 40;
+
+export const scoreMathOpacity = 0.75;
+
 /**
  * Calculates the font size based on the maximum width.
  * @param containerWidth The maximum width of the text.
  * @returns The calculated font size.
  */
 export const calculateFontSize = (containerWidth: number) => {
-    // const baseScale: number = Math.min(1 / stringLength * 200, 100);
-    const baseScale = 40;
-
     let widthFactor: number = containerWidth / 200;
-
     if (Number.isNaN(widthFactor)) { widthFactor = 1; }
-
-    return baseScale * widthFactor;
+    return baseScoreFontSize * widthFactor;
 };
 
 /**

--- a/src/components/PlayerTiles/AdditionTile/ScoreAfter.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreAfter.tsx
@@ -29,10 +29,12 @@ const ScoreAfter: React.FunctionComponent<Props> = ({ containerWidth, roundScore
 
     useEffect(() => {
         fontSize.value = withTiming(
-            roundScore == 0 ? 1 : calculateFontSize(containerWidth), { duration: animationDuration },
+            roundScore == 0 ? 1 : calculateFontSize(containerWidth) * 1.1,
+            { duration: animationDuration },
         );
         opacity.value = withTiming(
-            roundScore == 0 ? 0 : 1, { duration: animationDuration },
+            roundScore == 0 ? 0 : 1,
+            { duration: animationDuration },
         );
     }, [roundScore, containerWidth]);
 

--- a/src/components/PlayerTiles/AdditionTile/ScoreAfter.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreAfter.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 const ScoreAfter: React.FunctionComponent<Props> = ({ containerWidth, roundScore, totalScore, fontColor }) => {
-    const fontSize = useSharedValue(calculateFontSize(containerWidth, totalScore.toString().length));
+    const fontSize = useSharedValue(calculateFontSize(containerWidth));
     const opacity = useSharedValue(1);
 
     const animatedStyles = useAnimatedStyle(() => {
@@ -29,7 +29,7 @@ const ScoreAfter: React.FunctionComponent<Props> = ({ containerWidth, roundScore
 
     useEffect(() => {
         fontSize.value = withTiming(
-            roundScore == 0 ? 1 : calculateFontSize(containerWidth, totalScore.toString().length), { duration: animationDuration },
+            roundScore == 0 ? 1 : calculateFontSize(containerWidth), { duration: animationDuration },
         );
         opacity.value = withTiming(
             roundScore == 0 ? 0 : 1, { duration: animationDuration },

--- a/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
@@ -34,7 +34,7 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
         };
     });
 
-    const scaleFactor = roundScore == 0 ? 1 : .8;
+    const scaleFactor = roundScore == 0 ? 1 : .7;
 
     useEffect(() => {
         fontSize.value = withTiming(

--- a/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
@@ -6,7 +6,7 @@ import {
     withTiming
 } from 'react-native-reanimated';
 
-import { calculateFontSize, animationDuration, enteringAnimation } from './Helpers';
+import { calculateFontSize, animationDuration, enteringAnimation, multiLineScoreSizeMultiplier, singleLineScoreSizeMultiplier, scoreMathOpacity } from './Helpers';
 
 interface Props {
     roundScore: number;
@@ -34,7 +34,7 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
         };
     });
 
-    const scaleFactor = roundScore == 0 ? 1.2 : .7;
+    const scaleFactor = roundScore == 0 ? singleLineScoreSizeMultiplier : multiLineScoreSizeMultiplier;
 
     useEffect(() => {
         fontSize.value = withTiming(
@@ -43,7 +43,7 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
         );
 
         fontOpacity.value = withTiming(
-            roundScore == 0 ? 100 : 75,
+            roundScore == 0 ? 100 : scoreMathOpacity * 100,
             { duration: animationDuration }
         );
     }, [roundScore, containerWidth]);

--- a/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
@@ -21,14 +21,9 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
     totalScore,
     fontColor
 }) => {
-    // Determine the length of the first row of the score
-    const firstRowLength = (
-        roundScore == 0 ? 0 : roundScore.toString().length + 3
-    ) + totalScore.toString().length;
-
     const scoreBefore = totalScore - roundScore;
 
-    const fontSize = useSharedValue(calculateFontSize(containerWidth, firstRowLength));
+    const fontSize = useSharedValue(calculateFontSize(containerWidth));
     const fontOpacity = useSharedValue(100);
 
     const animatedStyles = useAnimatedStyle(() => {
@@ -39,9 +34,11 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
         };
     });
 
+    const scaleFactor = roundScore == 0 ? 1 : .8;
+
     useEffect(() => {
         fontSize.value = withTiming(
-            calculateFontSize(containerWidth, firstRowLength),
+            calculateFontSize(containerWidth) * scaleFactor,
             { duration: animationDuration }
         );
 

--- a/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
@@ -34,7 +34,7 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
         };
     });
 
-    const scaleFactor = roundScore == 0 ? 1 : .7;
+    const scaleFactor = roundScore == 0 ? 1.2 : .7;
 
     useEffect(() => {
         fontSize.value = withTiming(

--- a/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
@@ -15,9 +15,8 @@ interface Props {
     containerWidth: number;
 }
 
-const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, roundScore, totalScore, fontColor }) => {
-    const firstRowLength = (roundScore == 0 ? 0 : roundScore.toString().length + 3) + totalScore.toString().length;
-    const fontSizeRound = useSharedValue(calculateFontSize(containerWidth, firstRowLength));
+const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, roundScore, fontColor }) => {
+    const fontSizeRound = useSharedValue(calculateFontSize(containerWidth));
     const animatedStyles = useAnimatedStyle(() => {
         return {
             fontSize: fontSizeRound.value,
@@ -28,7 +27,7 @@ const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, roundScore
 
     useEffect(() => {
         fontSizeRound.value = withTiming(
-            calculateFontSize(containerWidth, firstRowLength), { duration: animationDuration }
+            calculateFontSize(containerWidth) * .8, { duration: animationDuration }
         );
 
     }, [roundScore, containerWidth]);

--- a/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
@@ -24,14 +24,16 @@ const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, roundScore
 
     const d = roundScore;
 
+
     useEffect(() => {
+        const scaleFactor = .7;
+
         fontSizeRound.value = withTiming(
-            calculateFontSize(containerWidth) * scaleFactor, { duration: animationDuration }
+            calculateFontSize(containerWidth) * scaleFactor,
+            { duration: animationDuration }
         );
 
     }, [roundScore, containerWidth]);
-
-    const scaleFactor = roundScore == 0 ? 1 : .7;
 
     if (roundScore == 0) {
         return <></>;

--- a/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
@@ -10,7 +10,6 @@ import { calculateFontSize, animationDuration } from './Helpers';
 
 interface Props {
     roundScore: number;
-    totalScore: number;
     fontColor: string;
     containerWidth: number;
 }
@@ -27,10 +26,12 @@ const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, roundScore
 
     useEffect(() => {
         fontSizeRound.value = withTiming(
-            calculateFontSize(containerWidth) * .8, { duration: animationDuration }
+            calculateFontSize(containerWidth) * scaleFactor, { duration: animationDuration }
         );
 
     }, [roundScore, containerWidth]);
+
+    const scaleFactor = roundScore == 0 ? 1 : .7;
 
     if (roundScore == 0) {
         return <></>;

--- a/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
@@ -6,7 +6,7 @@ import {
     withTiming
 } from 'react-native-reanimated';
 
-import { calculateFontSize, animationDuration } from './Helpers';
+import { calculateFontSize, animationDuration, multiLineScoreSizeMultiplier, scoreMathOpacity } from './Helpers';
 
 interface Props {
     roundScore: number;
@@ -15,21 +15,19 @@ interface Props {
 }
 
 const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, roundScore, fontColor }) => {
-    const fontSizeRound = useSharedValue(calculateFontSize(containerWidth));
+    const fontSize = useSharedValue(calculateFontSize(containerWidth));
+
     const animatedStyles = useAnimatedStyle(() => {
         return {
-            fontSize: fontSizeRound.value,
+            fontSize: fontSize.value,
         };
     });
 
     const d = roundScore;
 
-
     useEffect(() => {
-        const scaleFactor = .7;
-
-        fontSizeRound.value = withTiming(
-            calculateFontSize(containerWidth) * scaleFactor,
+        fontSize.value = withTiming(
+            calculateFontSize(containerWidth) * multiLineScoreSizeMultiplier,
             { duration: animationDuration }
         );
 
@@ -44,7 +42,8 @@ const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, roundScore
             <Animated.Text numberOfLines={1}
                 style={[animatedStyles, {
                     fontVariant: ['tabular-nums'],
-                    color: fontColor, opacity: .75
+                    color: fontColor,
+                    opacity: scoreMathOpacity
                 }]}>
                 {roundScore > 0 && " + "}
                 {roundScore < 0 && " - "}

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -68,14 +68,28 @@ const ScoreBoardScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         height: number;
     }
 
+    // TODO: In 7 person game portrait, last two are wrong when it should be last one is bigger.
+
     const calculateDimensions: DimensionValue = (index: number, total: number, rows: number, cols: number) => {
         if (width == null || height == null) return { width: 0, height: 0 };
         const h = height / rows;
-        // calculate width based on number of rows
+        //
+        // Calculate width based on number of rows
         // but if the index is in the last row, use the remainder
         let w;
-        if (total % rows > 0 && index >= total - total % rows) {
-            w = width / (total % rows);
+
+        /**
+         * If the last row has fewer columns than the rest
+         **/
+        const offsetLastRow = total % rows > 0;
+
+        /**
+         * First index of last row
+         **/
+        const firstOffsetIndex = total - total % cols;
+
+        if (offsetLastRow && index >= firstOffsetIndex) {
+            w = width / (total % cols);
         } else {
             w = width / cols;
         }

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -33,41 +33,34 @@ const ScoreBoardScreen: React.FunctionComponent<Props> = ({ navigation }) => {
 
     const desiredAspectRatio = 0.8;
 
-    let timeoutId: NodeJS.Timeout | null = null;
-
     const layoutHandler = (e: LayoutChangeEvent) => {
         const { width, height } = e.nativeEvent.layout;
-        if (timeoutId) {
-            clearTimeout(timeoutId);
-        }
 
-        timeoutId = setTimeout(() => {
-            setWidth(Math.round(width));
-            setHeight(Math.round(height));
+        setWidth(Math.round(width));
+        setHeight(Math.round(height));
 
-            let closestAspectRatio = Number.MAX_SAFE_INTEGER;
-            let bestRowCount = 1;
+        let closestAspectRatio = Number.MAX_SAFE_INTEGER;
+        let bestRowCount = 1;
 
-            for (let rows = 1; rows <= playerIds.length; rows++) {
-                const cols = Math.ceil(playerIds.length / rows);
+        for (let rows = 1; rows <= playerIds.length; rows++) {
+            const cols = Math.ceil(playerIds.length / rows);
 
-                if (playerIds.length % rows > 0 && rows - playerIds.length % rows > 1) {
-                    continue;
-                }
-
-                const w = width / cols;
-                const h = height / rows;
-                const ratio = w / h;
-
-                if (Math.abs(desiredAspectRatio - ratio) < Math.abs(desiredAspectRatio - closestAspectRatio)) {
-                    closestAspectRatio = ratio;
-                    bestRowCount = rows;
-                }
+            if (playerIds.length % rows > 0 && rows - playerIds.length % rows > 1) {
+                continue;
             }
 
-            setRows(bestRowCount);
-            setCols(Math.ceil(playerIds.length / bestRowCount));
-        }, 10);
+            const w = width / cols;
+            const h = height / rows;
+            const ratio = w / h;
+
+            if (Math.abs(desiredAspectRatio - ratio) < Math.abs(desiredAspectRatio - closestAspectRatio)) {
+                closestAspectRatio = ratio;
+                bestRowCount = rows;
+            }
+        }
+
+        setRows(bestRowCount);
+        setCols(Math.ceil(playerIds.length / bestRowCount));
     };
 
     type DimensionValue = (index: number, total: number, rows: number, cols: number) => {

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -63,40 +63,17 @@ const ScoreBoardScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         setCols(Math.ceil(playerIds.length / bestRowCount));
     };
 
-    type DimensionValue = (index: number, total: number, rows: number, cols: number) => {
+    type DimensionValue = (rows: number, cols: number) => {
         width: number;
         height: number;
     }
 
-    // TODO: In 7 person game portrait, last two are wrong when it should be last one is bigger.
-
-    const calculateDimensions: DimensionValue = (index: number, total: number, rows: number, cols: number) => {
+    const calculateDimensions: DimensionValue = (rows: number, cols: number) => {
         if (width == null || height == null) return { width: 0, height: 0 };
-        const h = height / rows;
-        //
-        // Calculate width based on number of rows
-        // but if the index is in the last row, use the remainder
-        let w;
-
-        /**
-         * If the last row has fewer columns than the rest
-         **/
-        const offsetLastRow = total % rows > 0;
-
-        /**
-         * First index of last row
-         **/
-        const firstOffsetIndex = total - total % cols;
-
-        if (offsetLastRow && index >= firstOffsetIndex) {
-            w = width / (total % cols);
-        } else {
-            w = width / cols;
-        }
 
         return {
-            width: Math.round(w),
-            height: Math.round(h)
+            width: Math.round(width / cols),
+            height: Math.round(height / rows)
         };
     };
 
@@ -113,8 +90,8 @@ const ScoreBoardScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                             fontColor={getContrastRatio('#' + palette[index % palette.length], '#000').number > 7 ? "#000000" : "#FFFFFF"}
                             cols={(rows != 0 && cols != 0) ? cols : 0}
                             rows={(rows != 0 && cols != 0) ? rows : 0}
-                            width={calculateDimensions(index, playerIds.length, rows, cols).width}
-                            height={calculateDimensions(index, playerIds.length, rows, cols).height}
+                            width={calculateDimensions(rows, cols).width}
+                            height={calculateDimensions(rows, cols).height}
                             index={index}
                         />
                     ))}


### PR DESCRIPTION
| Legacy | Width Dynamic | Fully Consistent |
|--------|--------|--------|
| ![Legacy](https://github.com/wyne/scorepad-react-native/assets/1986068/9f68ddd2-f1ed-4368-9e8d-0b6e454f0c2a) | ![Balanced](https://github.com/wyne/scorepad-react-native/assets/1986068/876ad5aa-d32b-410d-bafa-885f44ff6e76) | ![Fully Consistent](https://github.com/wyne/scorepad-react-native/assets/1986068/8500a52d-9a36-4c6b-80b1-4144ea15241c) |
| Original scaling method that is dynamic for each tile. Leads to a messy and inconsistent layout | Balancing consistency with responsiveness to larger cells. | Consistent across all cells, but also take into account device widths |
