### PR TITLE
Import export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "expo-crypto": "~55.0.15",
         "expo-dev-client": "~55.0.35",
         "expo-device": "~55.0.17",
+        "expo-document-picker": "~55.0.13",
+        "expo-file-system": "~55.0.22",
         "expo-haptics": "~55.0.14",
         "expo-image": "~55.0.11",
         "expo-keep-awake": "~55.0.8",
@@ -8174,6 +8176,15 @@
       "dependencies": {
         "ua-parser-js": "^0.7.33"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.13.tgz",
+      "integrity": "sha512-IhswJElhdzs3fKDEKW8KXYRoFkWGEsXRMYAZT46Yo56zqqy8yQXrczo33RSwD2hFzNQBdLT97SJL9N311UyS3g==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }
@@ -21150,6 +21161,11 @@
       "requires": {
         "ua-parser-js": "^0.7.33"
       }
+    },
+    "expo-document-picker": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.13.tgz",
+      "integrity": "sha512-IhswJElhdzs3fKDEKW8KXYRoFkWGEsXRMYAZT46Yo56zqqy8yQXrczo33RSwD2hFzNQBdLT97SJL9N311UyS3g=="
     },
     "expo-eas-client": {
       "version": "55.0.5",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "expo-crypto": "~55.0.15",
     "expo-dev-client": "~55.0.35",
     "expo-device": "~55.0.17",
+    "expo-document-picker": "~55.0.13",
+    "expo-file-system": "~55.0.22",
     "expo-haptics": "~55.0.14",
     "expo-image": "~55.0.11",
     "expo-keep-awake": "~55.0.8",

--- a/redux/GamesSlice.ts
+++ b/redux/GamesSlice.ts
@@ -103,6 +103,9 @@ const gamesSlice = createSlice({
                 }
             });
         },
+        restoreAllGames(state, action: PayloadAction<Record<string, GameState>>) {
+            gamesAdapter.setAll(state, action.payload);
+        },
 
     }
 });
@@ -319,6 +322,7 @@ export const {
     gameDelete,
     setSortSelector,
     reorderPlayers,
+    restoreAllGames,
 } = gamesSlice.actions;
 
 export default gamesSlice.reducer;

--- a/redux/PlayersSlice.ts
+++ b/redux/PlayersSlice.ts
@@ -29,6 +29,9 @@ const scoresSlice = createSlice({
         playerAdd(state, action: PayloadAction<ScoreState>) {
             playersAdapter.upsertOne(state, action.payload);
         },
+        restoreAllPlayers(state, action: PayloadAction<Record<string, ScoreState>>) {
+            playersAdapter.setAll(state, action.payload);
+        },
         playerRoundScoreIncrement: {
             reducer(
                 state,
@@ -63,6 +66,7 @@ export const {
     updatePlayer,
     removePlayer,
     playerAdd,
+    restoreAllPlayers,
     playerRoundScoreIncrement,
 } = scoresSlice.actions;
 

--- a/redux/SettingsSlice.ts
+++ b/redux/SettingsSlice.ts
@@ -108,6 +108,9 @@ const settingsSlice = createSlice({
         resetOnboarding(state) {
             state.onboarded = undefined;
         },
+        restoreSettings(_state, action: PayloadAction<SettingsState>) {
+            return action.payload;
+        },
     }
 });
 
@@ -131,6 +134,7 @@ export const {
     markFeatureNotificationSeen,
     resetSeenFeatureNotifications,
     resetOnboarding,
+    restoreSettings,
 } = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/redux/backup.ts
+++ b/redux/backup.ts
@@ -1,0 +1,99 @@
+import * as DocumentPicker from 'expo-document-picker';
+import { Paths, File } from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { Alert } from 'react-native';
+
+import { GameState, restoreAllGames } from './GamesSlice';
+import { ScoreState, restoreAllPlayers } from './PlayersSlice';
+import { restoreSettings, SettingsState } from './SettingsSlice';
+import { store } from './store';
+
+const BACKUP_VERSION = 1;
+
+interface BackupData {
+    version: number;
+    exportedAt: number;
+    games: {
+        entities: Record<string, GameState>;
+        ids: string[];
+    };
+    players: {
+        entities: Record<string, ScoreState>;
+        ids: string[];
+    };
+    settings: SettingsState;
+}
+
+export const exportBackup = async (): Promise<void> => {
+    try {
+        const state = store.getState();
+
+        const backup: BackupData = {
+            version: BACKUP_VERSION,
+            exportedAt: Date.now(),
+            games: {
+                entities: state.games.entities,
+                ids: state.games.ids,
+            },
+            players: {
+                entities: state.players.entities,
+                ids: state.players.ids,
+            },
+            settings: state.settings,
+        };
+
+        const json = JSON.stringify(backup, null, 2);
+        const filename = `ScorePad_Backup_${new Date().toISOString().split('T')[0]}.json`;
+        const backupFile = new File(Paths.cache, filename);
+        backupFile.create({ overwrite: true });
+        backupFile.write(json);
+
+        if (await Sharing.isAvailableAsync()) {
+            await Sharing.shareAsync(backupFile.uri, {
+                mimeType: 'application/json',
+                dialogTitle: 'Save ScorePad Backup',
+            });
+        } else {
+            Alert.alert('Export Unavailable', 'Sharing is not available on this device.');
+        }
+    } catch {
+        Alert.alert('Export Failed', 'An error occurred while exporting the backup.');
+    }
+};
+
+export const importBackup = async (): Promise<void> => {
+    try {
+        const result = await DocumentPicker.getDocumentAsync({
+            type: 'application/json',
+            copyToCacheDirectory: true,
+        });
+
+        if (result.canceled) return;
+
+        const file = result.assets[0];
+        const backupFile = new File(file.uri);
+        const content = await backupFile.text();
+
+        let backup: BackupData;
+        try {
+            backup = JSON.parse(content);
+        } catch {
+            Alert.alert('Import Failed', 'The selected file is not a valid JSON file.');
+            return;
+        }
+
+        if (!backup.games?.entities || !backup.players?.entities) {
+            Alert.alert('Import Failed', 'The selected file is not a valid ScorePad backup.');
+            return;
+        }
+
+        const dispatch = store.dispatch;
+        dispatch(restoreAllGames(backup.games.entities));
+        dispatch(restoreAllPlayers(backup.players.entities));
+        dispatch(restoreSettings(backup.settings));
+
+        Alert.alert('Restore Complete', 'Your data has been restored from the backup.');
+    } catch {
+        Alert.alert('Import Failed', 'An error occurred while importing the backup.');
+    }
+};

--- a/scripts/install-ipa.sh
+++ b/scripts/install-ipa.sh
@@ -3,113 +3,167 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
-# ---- Step 1: Pick an IPA ----
-IPAS=()
-while IFS= read -r f; do
-  IPAS+=("$f")
-done < <(ls -1t "$ROOT_DIR"/*.ipa 2>/dev/null || true)
+COLOR_RESET='\033[0m'
+COLOR_BOLD='\033[1m'
+COLOR_CYAN='\033[36m'
+COLOR_YELLOW='\033[33m'
+COLOR_DIM='\033[2m'
 
-if [ ${#IPAS[@]} -eq 0 ]; then
-  echo "No .ipa files found in $ROOT_DIR" >&2
-  exit 1
-fi
+relative_time() {
+    local epoch=$1 now diff
+    now=$(date +%s)
+    diff=$((now - epoch))
+    if   [ $diff -lt 60 ];    then echo "just now"
+    elif [ $diff -lt 3600 ];  then echo "$((diff / 60))m ago"
+    elif [ $diff -lt 86400 ]; then echo "$((diff / 3600))h ago"
+    elif [ $diff -lt 172800 ]; then echo "yesterday"
+    else echo "$((diff / 86400))d ago"
+    fi
+}
 
-echo "Available .ipa files:"
-for i in "${!IPAS[@]}"; do
-  name=$(basename "${IPAS[$i]}")
-  f="${IPAS[$i]}"
-
-  # Parse timestamp from build-<epoch_ms>.ipa filename
-  ts=""
-  if [[ "$name" =~ ^build-([0-9]+)\.ipa$ ]]; then
-    epoch_ms="${BASH_REMATCH[1]}"
-    ts=$(date -r $((epoch_ms / 1000)) "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown")
-  fi
-  mtime=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$f" 2>/dev/null || echo "")
-
-  # Extract version/bundle info from IPA
-  ver=""
-  if plist=$(unzip -p "$f" "Payload/*.app/Info.plist" 2>/dev/null); then
-    ver=$(echo "$plist" | plutil -convert json -o - - 2>/dev/null | python3 -c "
+ipa_info() {
+    local f=$1 name=$2
+    local ver="" ts="" rel=""
+    if [[ "$name" =~ ^build-([0-9]+)\.ipa$ ]]; then
+        local e=$((BASH_REMATCH[1] / 1000))
+        ts=$(date -r "$e" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown")
+        rel=$(relative_time "$e")
+    fi
+    if plist=$(unzip -p "$f" "Payload/*.app/Info.plist" 2>/dev/null); then
+        ver=$(echo "$plist" | plutil -convert json -o - - 2>/dev/null | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
-bundle = d.get('CFBundleIdentifier', '')
-if bundle.endswith('.dev'): variant = 'dev'
-elif bundle.endswith('.preview'): variant = 'preview'
-else: variant = 'production'
+b = d.get('CFBundleIdentifier', '')
 v = d.get('CFBundleShortVersionString', '?')
-b = d.get('CFBundleVersion', '?')
-print(f'v{v} (build {b})  {variant}  {bundle}')
+n = d.get('CFBundleVersion', '?')
+if b.endswith('.dev'): variant = 'dev'
+elif b.endswith('.preview'): variant = 'preview'
+else: variant = 'production'
+print(f'v{v} (build {n})  {variant}')
 " 2>/dev/null || echo "")
-  fi
+    fi
+    echo "$ver|$ts|$rel"
+}
 
-  echo "  $((i+1)). $name"
-  echo "     $ver    built: $ts"
-done
+# ---- Step 1: Pick an IPA ----
+IPAS=()
+while IFS= read -r f; do IPAS+=("$f"); done < <(ls -1t "$ROOT_DIR"/*.ipa 2>/dev/null || true)
 
-printf "Select IPA [1-%d]: " "${#IPAS[@]}"
-read -r ipa_idx
-ipa_idx=$((ipa_idx - 1))
-if [ "$ipa_idx" -lt 0 ] || [ "$ipa_idx" -ge "${#IPAS[@]}" ]; then
-  echo "Invalid selection" >&2
-  exit 1
+if [ ${#IPAS[@]} -eq 0 ]; then
+    echo "No .ipa files found in $ROOT_DIR" >&2
+    exit 1
 fi
-IPA_PATH="${IPAS[$ipa_idx]}"
-echo "Selected: $IPA_PATH"
+
+if command -v fzf &>/dev/null; then
+    echo "Select an IPA:"
+    IPA_PATH=$(
+        for f in "${IPAS[@]}"; do
+            name=$(basename "$f")
+            IFS='|' read -r ver ts rel <<< "$(ipa_info "$f" "$name")"
+            if [ -n "$rel" ]; then ts_disp="${ts} (${rel})"; else ts_disp="$ts"; fi
+            printf "%s|%s|%s|%s\n" "$name" "$ver" "$ts_disp" "$f"
+        done | fzf \
+            --prompt='> ' \
+            --with-nth='1..3' \
+            --delimiter='|' \
+            --preview "
+                f=\$(echo {} | cut -d'|' -f4)
+                unzip -p \"\$f\" 'Payload/*.app/Info.plist' 2>/dev/null | plutil -convert json -o - - 2>/dev/null | python3 -c \"
+import sys, json
+d = json.load(sys.stdin)
+print('Identifier:', d.get('CFBundleIdentifier', '?'))
+print('Version:', d.get('CFBundleShortVersionString', '?'))
+print('Build:', d.get('CFBundleVersion', '?'))
+print('Min OS:', d.get('MinimumOSVersion', '?'))
+\" 2>/dev/null || echo 'No metadata available'
+            " \
+            --preview-window=right:40%:wrap \
+            --height=~50% \
+            2>/dev/null || true)
+    if [ -z "$IPA_PATH" ]; then echo "Cancelled." >&2; exit 1; fi
+    IPA_PATH=$(echo "$IPA_PATH" | cut -d'|' -f4)
+else
+    echo -e "${COLOR_BOLD}Select an IPA:${COLOR_RESET}"
+    for i in "${!IPAS[@]}"; do
+        name=$(basename "${IPAS[$i]}")
+        IFS='|' read -r ver ts rel <<< "$(ipa_info "${IPAS[$i]}" "$name")"
+        ts_disp="${ts:+$ts (${rel:-$ts})}"
+        echo -e "  $((i+1)). ${COLOR_CYAN}${name}${COLOR_RESET}  ${COLOR_YELLOW}${ver}${COLOR_RESET}  ${COLOR_DIM}${ts_disp}${COLOR_RESET}"
+    done
+    printf "Select IPA [1-%d]: " "${#IPAS[@]}"
+    read -r n; n=$((n - 1))
+    if [ "$n" -lt 0 ] || [ "$n" -ge "${#IPAS[@]}" ]; then echo "Invalid selection" >&2; exit 1; fi
+    IPA_PATH="${IPAS[$n]}"
+fi
+
+echo -e "Selected: ${COLOR_CYAN}$(basename "$IPA_PATH")${COLOR_RESET}"
 echo
 
 # ---- Step 2: List devices ----
 echo "Fetching available devices..."
-DEVICES_JSON=$(mktemp)
-xcrun devicectl list devices --json-output "$DEVICES_JSON" >/dev/null 2>&1
+JSON=$(mktemp)
+xcrun devicectl list devices --json-output "$JSON" >/dev/null 2>&1
 
-DEVICE_NAMES=()
-DEVICE_IDS=()
-while IFS=$'\t' read -r name id; do
-  DEVICE_NAMES+=("$name")
-  DEVICE_IDS+=("$id")
+DEVICES=()
+while IFS=$'\t' read -r name id model; do
+    DEVICES+=("$name|$id|$model")
 done < <(python3 -c "
 import json, sys
-with open('$DEVICES_JSON') as f:
+with open('$JSON') as f:
     data = json.load(f)
 for d in data['result']['devices']:
-    state = d.get('connectionProperties', {}).get('tunnelState', '')
-    pairing = d.get('connectionProperties', {}).get('pairingState', '')
-    # Only show devices that are paired and reachable
-    if pairing != 'paired':
-        continue
-    if state == 'unavailable':
+    s = d.get('connectionProperties', {}).get('tunnelState', '')
+    p = d.get('connectionProperties', {}).get('pairingState', '')
+    if p != 'paired' or s == 'unavailable':
         continue
     name = d['deviceProperties']['name']
     ident = d['identifier']
     model = d.get('hardwareProperties', {}).get('productType', '')
-    print(f'{name}\t{ident}')
+    print(f'{name}\t{ident}\t{model}')
 " 2>/dev/null)
-rm -f "$DEVICES_JSON"
+rm -f "$JSON"
 
-if [ ${#DEVICE_NAMES[@]} -eq 0 ]; then
-  echo "No available (paired) devices found. Make sure Wireless Debugging is enabled on your device." >&2
-  exit 1
+if [ ${#DEVICES[@]} -eq 0 ]; then
+    echo "No available (paired) devices found. Make sure Wireless Debugging is enabled on your device." >&2
+    exit 1
 fi
 
-echo "Available devices:"
-for i in "${!DEVICE_NAMES[@]}"; do
-  echo "  $((i+1)). ${DEVICE_NAMES[$i]} (${DEVICE_IDS[$i]})"
-done
-
-printf "Select device [1-%d]: " "${#DEVICE_NAMES[@]}"
-read -r dev_idx
-dev_idx=$((dev_idx - 1))
-if [ "$dev_idx" -lt 0 ] || [ "$dev_idx" -ge "${#DEVICE_NAMES[@]}" ]; then
-  echo "Invalid selection" >&2
-  exit 1
+if command -v fzf &>/dev/null; then
+    echo "Select a device:"
+    selected=$(
+        for line in "${DEVICES[@]}"; do
+            name=$(echo "$line" | cut -d'|' -f1)
+            model=$(echo "$line" | cut -d'|' -f3)
+            id=$(echo "$line" | cut -d'|' -f2)
+            printf "%s|%s|%s\n" "$name" "$model" "$id"
+        done | fzf \
+            --prompt='> ' \
+            --with-nth='1,2' \
+            --delimiter='|' \
+            --height=~50% \
+            2>/dev/null || true)
+    if [ -z "$selected" ]; then echo "Cancelled." >&2; exit 1; fi
+    SELECTED_DEVICE=$(echo "$selected" | cut -d'|' -f3)
+    SELECTED_NAME=$(echo "$selected" | cut -d'|' -f1)
+else
+    echo -e "${COLOR_BOLD}Select a device:${COLOR_RESET}"
+    for i in "${!DEVICES[@]}"; do
+        name=$(echo "${DEVICES[$i]}" | cut -d'|' -f1)
+        model=$(echo "${DEVICES[$i]}" | cut -d'|' -f3)
+        echo -e "  $((i+1)). ${COLOR_CYAN}${name}${COLOR_RESET}  ${COLOR_DIM}${model}${COLOR_RESET}"
+    done
+    printf "Select device [1-%d]: " "${#DEVICES[@]}"
+    read -r n; n=$((n - 1))
+    if [ "$n" -lt 0 ] || [ "$n" -ge "${#DEVICES[@]}" ]; then echo "Invalid selection" >&2; exit 1; fi
+    SELECTED_DEVICE=$(echo "${DEVICES[$n]}" | cut -d'|' -f2)
+    SELECTED_NAME=$(echo "${DEVICES[$n]}" | cut -d'|' -f1)
 fi
-SELECTED_DEVICE="${DEVICE_IDS[$dev_idx]}"
-echo "Selected: ${DEVICE_NAMES[$dev_idx]} ($SELECTED_DEVICE)"
+
+echo -e "Selected: ${COLOR_CYAN}${SELECTED_NAME}${COLOR_RESET}"
 echo
 
 # ---- Step 3: Install ----
-echo "Installing $(basename "$IPA_PATH") on ${DEVICE_NAMES[$dev_idx]}..."
+echo "Installing $(basename "$IPA_PATH")..."
 xcrun devicectl device install app --device "$SELECTED_DEVICE" "$IPA_PATH"
 
 echo

--- a/src/components/Buttons/CheckButton.test.tsx
+++ b/src/components/Buttons/CheckButton.test.tsx
@@ -75,7 +75,7 @@ describe('CheckButton', () => {
         });
     }, 10000);
 
-    it('should navigate back to share screen screen when pressed from share screen', async () => {
+    it('should navigate back when pressed from share screen', async () => {
         const store = mockStore();
 
         const { getByRole } = render(
@@ -88,7 +88,7 @@ describe('CheckButton', () => {
         fireEvent.press(button);
 
         await waitFor(() => {
-            expect(navigation.navigate).toHaveBeenCalledWith('Share');
+            expect(navigation.goBack).toHaveBeenCalled();
         });
     }, 10000);
 

--- a/src/components/Buttons/CheckButton.tsx
+++ b/src/components/Buttons/CheckButton.tsx
@@ -37,7 +37,7 @@ const CheckButton: React.FunctionComponent<Props> = ({ navigation, route }) => {
             if (route?.params?.source === 'list_screen') {
                 navigation.navigate('List');
             } else if (route?.params?.source === 'share_screen') {
-                navigation.navigate('Share');
+                navigation.goBack();
             } else if (route?.params?.source === 'new_game') {
                 navigation.navigate('Game');
             } else {

--- a/src/components/EditGame.test.tsx
+++ b/src/components/EditGame.test.tsx
@@ -34,6 +34,13 @@ jest.mock('react-native-elements', () => ({
     },
 }));
 
+// Mock @react-navigation/native
+jest.mock('@react-navigation/native', () => ({
+    useNavigation: () => ({
+        addListener: jest.fn(() => jest.fn()),
+    }),
+}));
+
 // Mock PaletteSelector component
 jest.mock('./ColorPalettes/PaletteSelector', () => {
     return function MockPaletteSelector() {
@@ -213,12 +220,17 @@ describe('EditGame', () => {
 
         const input = getByTestId('game-title-input');
         
-        // Change text to new title
         fireEvent.changeText(input, 'New Game Title');
 
-        // Check that the change was dispatched to Redux
         const state = store.getState();
-        expect(state.games.entities['game-1']?.title).toBe('New Game Title');
+        expect(state.games.entities['game-1']?.title).toBe('Test Game');
+
+        fireEvent(input, 'endEditing', {
+            nativeEvent: { text: 'New Game Title' }
+        });
+
+        const stateAfter = store.getState();
+        expect(stateAfter.games.entities['game-1']?.title).toBe('New Game Title');
     });
 
     it('should set title to "Untitled" when empty text is entered', () => {
@@ -246,10 +258,11 @@ describe('EditGame', () => {
 
         const input = getByTestId('game-title-input');
         
-        // Change text to empty string
         fireEvent.changeText(input, '');
+        fireEvent(input, 'endEditing', {
+            nativeEvent: { text: '' }
+        });
 
-        // Check that title was set to "Untitled"
         const state = store.getState();
         expect(state.games.entities['game-1']?.title).toBe('Untitled');
     });
@@ -444,10 +457,11 @@ describe('EditGame', () => {
 
         const input = getByTestId('game-title-input');
         
-        // Change text to long title
         fireEvent.changeText(input, longTitle);
+        fireEvent(input, 'endEditing', {
+            nativeEvent: { text: longTitle }
+        });
 
-        // Check that the title was updated
         const state = store.getState();
         expect(state.games.entities['game-1']?.title).toBe(longTitle);
     });
@@ -479,10 +493,11 @@ describe('EditGame', () => {
 
         const input = getByTestId('game-title-input');
         
-        // Change text to title with special characters
         fireEvent.changeText(input, specialTitle);
+        fireEvent(input, 'endEditing', {
+            nativeEvent: { text: specialTitle }
+        });
 
-        // Check that the title was updated correctly
         const state = store.getState();
         expect(state.games.entities['game-1']?.title).toBe(specialTitle);
     });

--- a/src/components/EditGame.tsx
+++ b/src/components/EditGame.tsx
@@ -20,6 +20,7 @@ const EditGame = ({ }) => {
     const navigation = useNavigation();
 
     const commitTitle = (title: string) => {
+        if (currentGame == undefined) return;
         const finalTitle = title == '' ? UNTITLED : title;
         setLocalTitle(finalTitle);
 

--- a/src/components/EditGame.tsx
+++ b/src/components/EditGame.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
+import { useNavigation } from '@react-navigation/native';
 import { NativeSyntheticEvent, StyleSheet, Text, TextInputEndEditingEventData, View } from 'react-native';
 import { Input } from 'react-native-elements';
 
@@ -16,37 +17,36 @@ const EditGame = ({ }) => {
     const currentGame = useAppSelector(selectCurrentGame);
     const [localTitle, setLocalTitle] = useState(currentGame?.title ?? '');
 
-    if (typeof currentGame == 'undefined') return null;
+    const navigation = useNavigation();
 
-    const onEndEditingHandler = (e: NativeSyntheticEvent<TextInputEndEditingEventData>) => {
-        const text = e.nativeEvent.text;
-
-        if (text == '') {
-            setLocalTitle(UNTITLED);
-            saveGameTitle(UNTITLED);
-        } else {
-            saveGameTitle(text);
-        }
-    };
-
-    const onChangeTextHandler = (text: string) => {
-        if (text == '') {
-            saveGameTitle(UNTITLED);
-        } else {
-            saveGameTitle(text);
-        }
-        setLocalTitle(text);
-    };
-
-    const saveGameTitle = (title: string) => {
-        setLocalTitle(title);
+    const commitTitle = (title: string) => {
+        const finalTitle = title == '' ? UNTITLED : title;
+        setLocalTitle(finalTitle);
 
         dispatch(updateGame({
             id: currentGame.id,
             changes: {
-                title: title == '' ? UNTITLED : title,
+                title: finalTitle,
             }
         }));
+    };
+
+    useEffect(() => {
+        const unsubscribe = navigation.addListener('beforeRemove', () => {
+            commitTitle(localTitle);
+        });
+        return unsubscribe;
+    }, [navigation, localTitle]);
+
+    if (typeof currentGame == 'undefined') return null;
+
+    const onEndEditingHandler = (e: NativeSyntheticEvent<TextInputEndEditingEventData>) => {
+        const text = e.nativeEvent.text;
+        commitTitle(text);
+    };
+
+    const onChangeTextHandler = (text: string) => {
+        setLocalTitle(text);
     };
 
     return (
@@ -59,8 +59,7 @@ const EditGame = ({ }) => {
                     onEndEditing={onEndEditingHandler}
                     onBlur={() => {
                         if (localTitle == '') {
-                            setLocalTitle(UNTITLED);
-                            saveGameTitle(UNTITLED);
+                            commitTitle(UNTITLED);
                         }
                     }}
                     placeholder={UNTITLED}

--- a/src/screens/AppInfoScreen.tsx
+++ b/src/screens/AppInfoScreen.tsx
@@ -5,6 +5,7 @@ import { ParamListBase } from '@react-navigation/routers';
 import * as Application from 'expo-application';
 import { Alert, Linking, Platform, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 
+import { exportBackup, importBackup } from '../../redux/backup';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { markFeatureNotificationSeen, resetOnboarding, resetSeenFeatureNotifications, setKeepScreenAwake, toggleShowPlayerIndex, toggleShowPointParticles } from '../../redux/SettingsSlice';
 import { logEvent } from '../Analytics';
@@ -109,6 +110,21 @@ const AppInfoScreen: React.FunctionComponent<Props> = ({ navigation }) => {
             });
         }
     };
+    const handleRestore = () => {
+        Alert.alert(
+            'Restore from Backup',
+            'This will replace all current games, players, and scores with the data from the backup. This action cannot be undone.',
+            [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'Restore', style: 'destructive', onPress: importBackup },
+            ]
+        );
+    };
+
+    const handleExport = async () => {
+        await exportBackup();
+    };
+
     const alertWithVersion = async () => {
         Alert.alert('ScorePad with Rounds\n' +
             `v${appVersion} (${buildNumber})\n` +
@@ -194,6 +210,12 @@ const AppInfoScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                     }} />
                 </Section>
             )}
+
+            <Section title="Backup">
+                <DisclosureRow label="Export Backup" onPress={handleExport} />
+                <SectionSeparator />
+                <DisclosureRow label="Restore from Backup" onPress={handleRestore} />
+            </Section>
 
             <Section title="Help">
                 <DisclosureRow label="View Tutorial" onPress={() => {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -29,7 +29,6 @@ const SettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     const dispatch = useAppDispatch();
 
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
-    const currentGame = useAppSelector(selectCurrentGame);
     const playerIds = useAppSelector(state => selectCurrentGame(state)?.playerIds);
     const [edit, setEdit] = React.useState(false);
 
@@ -43,8 +42,6 @@ const SettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     if (typeof playerIds == 'undefined') return null;
 
     const addPlayerHandler = async () => {
-        if (currentGame == undefined) return;
-
         dispatch(addPlayer({
             gameId: currentGameId,
             playerName: `Player ${playerIds.length + 1}`,


### PR DESCRIPTION
## Summary

Adds import/export backup functionality, allowing users to export all game data and restore it later.

## Changes

### Backup system
- New `redux/backup.ts` module with `exportBackup()` and `importBackup()` functions
- Backup format includes all games, players, and settings in a versioned JSON file
- Uses `expo-document-picker` and `expo-file-system` for file save/open

### Redux changes
- Added `restoreAllGames` action to `GamesSlice` (uses `setAll` on the entity adapter)
- Added `restoreAllPlayers` action to `PlayersSlice` (uses `setAll` on the entity adapter)
- Added `restoreSettings` action to `SettingsSlice`

### UI
- `AppInfoScreen`: new "Backup" section with "Export Backup" and "Restore from Backup" options
- "Restore" shows a destructive confirmation alert before proceeding
- `EditGame`: refactored title save logic, removed `saveGameTitle` helper in favor of `commitTitle`

### Dependencies
- Added `expo-document-picker` and `expo-file-system"

### Scripts
- Updated `scripts/install-ipa.sh` with improved iOS simulator installation flow

### Cleanup
- Removed unused `currentGame` selector usage from `SettingsScreen`