### PR TITLE
Fix share

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "react-native-size-matters": "^0.4.0",
         "react-native-svg": "15.15.3",
         "react-native-video": "^6.19.2",
-        "react-native-view-shot": "~4.0.3",
+        "react-native-view-shot": "5.1.0",
         "react-native-web": "^0.21.0",
         "react-native-worklets": "0.7.4",
         "react-redux": "^8.0.2",
@@ -13464,16 +13464,20 @@
       }
     },
     "node_modules/react-native-view-shot": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
-      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-5.1.0.tgz",
+      "integrity": "sha512-JZgElCD82aO+hejIF/leUzI7JufL9mgJ6ChzGWIcdZ2ajpaEvvSnvIcw0qD32XWkrbId8wfSbyz/4u/ulTQzQA==",
       "license": "MIT",
       "dependencies": {
         "html2canvas": "^1.4.1"
       },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
+      },
       "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
+        "react": ">=18.0.0",
+        "react-native": ">=0.76.0"
       }
     },
     "node_modules/react-native-web": {
@@ -24458,9 +24462,9 @@
       "integrity": "sha512-gh5dBMGSHywKr8+p4azRXrFQgT+QTmS1tI4sz6kVRjSENORfsrGGLQzmyo/7S9m+ZOTLWQJ3h8ONaXxR4F2Fcw=="
     },
     "react-native-view-shot": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
-      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-5.1.0.tgz",
+      "integrity": "sha512-JZgElCD82aO+hejIF/leUzI7JufL9mgJ6ChzGWIcdZ2ajpaEvvSnvIcw0qD32XWkrbId8wfSbyz/4u/ulTQzQA==",
       "requires": {
         "html2canvas": "^1.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-native-size-matters": "^0.4.0",
     "react-native-svg": "15.15.3",
     "react-native-video": "^6.19.2",
-    "react-native-view-shot": "~4.0.3",
+    "react-native-view-shot": "5.1.0",
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.7.4",
     "react-redux": "^8.0.2",

--- a/src/screens/ShareScreen.test.tsx
+++ b/src/screens/ShareScreen.test.tsx
@@ -307,7 +307,6 @@ describe('ShareScreen', () => {
                     quality: 1,
                     format: 'png',
                     snapshotContentContainer: true,
-                    fileName: 'Test Game.png',
                 }
             );
         });

--- a/src/screens/ShareScreen.tsx
+++ b/src/screens/ShareScreen.tsx
@@ -36,21 +36,24 @@ const ShareScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     const exportImage = async () => {
         if (roundsScrollViewEl.current == null) return;
 
-        captureRef(roundsScrollViewEl, {
-            result: 'tmpfile',
-            quality: 1,
-            format: 'png',
-            snapshotContentContainer: true,
-            fileName: `${currentGame?.title}.png`,
-        }).then(uri => {
-            Sharing.shareAsync(uri, {
+        try {
+            const uri = await captureRef(roundsScrollViewEl, {
+                result: 'tmpfile',
+                quality: 1,
+                format: 'png',
+                snapshotContentContainer: true,
+            });
+
+            await Sharing.shareAsync(uri, {
                 mimeType: 'image/png',
                 dialogTitle: 'Share Scoreboard',
                 UTI: 'image/png',
             });
-        });
 
-        await logEvent('share_image');
+            await logEvent('share_image');
+        } catch (error) {
+            console.error('Failed to capture or share image:', error);
+        }
     };
 
     return (


### PR DESCRIPTION
## Summary

Fixes the share image functionality by upgrading `react-native-view-shot` and modernizing the capture/sharing code.

## Changes

- Upgraded `react-native-view-shot` from `~4.0.3` to `5.1.0` (requires React Native >=0.76.0)
- Refactored `ShareScreen.tsx`: replaced promise chaining (`.then()`) with async/await for cleaner error handling
- Added error handling with `try/catch` around the capture and share flow
- Removed unsupported `fileName` option (removed in view-shot v5 API)
- Removed stale `fileName` assertion from `ShareScreen.test.tsx`