### PR TITLE
chore: upgrade @reduxjs/toolkit to v2 and react-redux to v9

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
         '^.+\\.tsx?$': 'babel-jest',
     },
     transformIgnorePatterns: [
-        'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)'
+        'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|immer|react-redux|@reduxjs/toolkit)'
     ],
     testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@react-native-picker/picker": "2.11.4",
         "@react-navigation/native": "^7.2.4",
         "@react-navigation/native-stack": "^7.15.1",
-        "@reduxjs/toolkit": "^1.9.3",
+        "@reduxjs/toolkit": "^2.12.0",
         "colorsheet": "^1.0.5",
         "dotenv": "^16.0.3",
         "expo": "~55.0.26",
@@ -70,7 +70,7 @@
         "react-native-view-shot": "5.1.0",
         "react-native-web": "^0.21.0",
         "react-native-worklets": "0.7.4",
-        "react-redux": "^8.0.2",
+        "react-redux": "^9.0.0",
         "redux-persist": "^6.0.0",
         "semver": "^7.8.1",
         "typescript": "~5.9.2"
@@ -4678,17 +4678,21 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.7",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "license": "MIT",
       "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -4716,6 +4720,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",
@@ -4909,14 +4925,6 @@
       "version": "2.0.45",
       "license": "MIT"
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "license": "MIT"
@@ -5033,7 +5041,9 @@
       "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -9459,7 +9469,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -13591,45 +13603,27 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "8.1.3",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
       },
       "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
           "optional": true
         },
         "redux": {
           "optional": true
         }
       }
-    },
-    "node_modules/react-redux/node_modules/react-is": {
-      "version": "18.2.0",
-      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -13674,11 +13668,10 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-mock-store": {
       "version": "1.5.4",
@@ -13696,10 +13689,12 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.2",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
       "license": "MIT",
       "peerDependencies": {
-        "redux": "^4"
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -13823,7 +13818,9 @@
       "license": "MIT"
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -18956,12 +18953,16 @@
       }
     },
     "@reduxjs/toolkit": {
-      "version": "1.9.7",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "requires": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
       }
     },
     "@sinclair/typebox": {
@@ -18978,6 +18979,16 @@
       "requires": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "@testing-library/dom": {
       "version": "9.3.3",
@@ -19115,13 +19126,6 @@
     "@types/hammerjs": {
       "version": "2.0.45"
     },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.6"
     },
@@ -19220,7 +19224,9 @@
       "dev": true
     },
     "@types/use-sync-external-store": {
-      "version": "0.0.3"
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "@types/yargs": {
       "version": "17.0.32",
@@ -21987,7 +21993,9 @@
       }
     },
     "immer": {
-      "version": "9.0.21"
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -24520,19 +24528,12 @@
       }
     },
     "react-redux": {
-      "version": "8.1.3",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "requires": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "18.2.0"
-        }
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
       }
     },
     "react-refresh": {
@@ -24567,10 +24568,9 @@
       }
     },
     "redux": {
-      "version": "4.2.1",
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "redux-mock-store": {
       "version": "1.5.4",
@@ -24583,7 +24583,9 @@
       "version": "6.0.0"
     },
     "redux-thunk": {
-      "version": "2.4.2"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="
     },
     "reflect.getprototypeof": {
       "version": "1.0.10",
@@ -24671,7 +24673,9 @@
       "dev": true
     },
     "reselect": {
-      "version": "4.1.8"
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="
     },
     "resolve": {
       "version": "1.22.12",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@react-native-picker/picker": "2.11.4",
     "@react-navigation/native": "^7.2.4",
     "@react-navigation/native-stack": "^7.15.1",
-    "@reduxjs/toolkit": "^1.9.3",
+    "@reduxjs/toolkit": "^2.12.0",
     "colorsheet": "^1.0.5",
     "dotenv": "^16.0.3",
     "expo": "~55.0.26",
@@ -78,7 +78,7 @@
     "react-native-view-shot": "5.1.0",
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.7.4",
-    "react-redux": "^8.0.2",
+    "react-redux": "^9.0.0",
     "redux-persist": "^6.0.0",
     "semver": "^7.8.1",
     "typescript": "~5.9.2"

--- a/redux/GamesSlice.test.ts
+++ b/redux/GamesSlice.test.ts
@@ -1,6 +1,5 @@
 
-import { configureStore, EntityId, EntityState } from '@reduxjs/toolkit';
-import { Store } from 'redux';
+import { configureStore, EntityState, Store } from '@reduxjs/toolkit';
 
 import gamesReducer, {
     asyncCreateGame,
@@ -27,7 +26,7 @@ jest.mock('expo-crypto', () => ({
 }));
 
 describe('games reducer', () => {
-    let store: Store<EntityState<GameState>>;
+    let store: Store<EntityState<GameState, string>>;
 
     beforeEach(() => {
         store = configureStore({
@@ -144,7 +143,7 @@ describe('asyncCreateGame', () => {
 
         const finalState = store.getState();
 
-        const newGameId: EntityId = finalState.games.ids[0];
+        const newGameId: string = finalState.games.ids[0];
         const newGame = finalState.games.entities[newGameId];
 
         expect(finalState.games.ids.length).toBe(1);
@@ -170,13 +169,13 @@ describe('asyncRematchGame', () => {
 
         await store.dispatch(asyncCreateGame({ gameCount, playerCount }));
 
-        const originalGameId: EntityId = store.getState().games.ids[0];
+        const originalGameId: string = store.getState().games.ids[0];
 
         await store.dispatch(asyncRematchGame({ gameId: originalGameId.toString() }));
 
         const finalState = store.getState();
 
-        const rematchGameId: EntityId = finalState.games.ids[1];
+        const rematchGameId: string = finalState.games.ids[1];
         const rematchGame = finalState.games.entities[rematchGameId];
 
         expect(finalState.games.ids.length).toBe(2);

--- a/redux/hooks.ts
+++ b/redux/hooks.ts
@@ -1,8 +1,6 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import type { RootState, AppDispatch } from './store';
 
-// Use throughout your app instead of plain `useDispatch` and `useSelector`
-type DispatchFunc = () => AppDispatch
-export const useAppDispatch: DispatchFunc = useDispatch;
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();


### PR DESCRIPTION
Closes #558

## Changes

- `@reduxjs/toolkit` `^1.9.3` → `^2.12.0`
- `react-redux` `^8.0.2` → `^9.0.0`
- `redux/hooks.ts`: replaced deprecated `TypedUseSelectorHook` with `.withTypes()` (removed in react-redux 9)
- `redux/GamesSlice.test.ts`: replaced removed `EntityId` type with `string`, fixed `EntityState` generic syntax, moved `Store` import to `@reduxjs/toolkit`
- `jest.config.ts`: added `immer`, `react-redux`, `@reduxjs/toolkit` to `transformIgnorePatterns` (these packages now ship ESM)

## Benefits of upgrading

See summary below.