### PR TITLE
chore: migrate Firebase to modular API and fix Analytics issues

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import analytics from '@react-native-firebase/analytics';
+import { getAnalytics, setAnalyticsCollectionEnabled } from '@react-native-firebase/analytics';
 import { StatusBar } from 'expo-status-bar';
 import { View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -16,7 +16,7 @@ import { GameSheetContextProvider } from './src/components/Sheets/GameSheetConte
 import { Navigation } from './src/Navigation';
 
 if (process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS == 'false') {
-    analytics().setAnalyticsCollectionEnabled(false);
+    setAnalyticsCollectionEnabled(getAnalytics(), false);
 }
 
 export default function App() {

--- a/redux/PlayersSlice.ts
+++ b/redux/PlayersSlice.ts
@@ -1,4 +1,4 @@
-import crashlytics from '@react-native-firebase/crashlytics';
+import { getCrashlytics, recordError } from '@react-native-firebase/crashlytics';
 import { PayloadAction, createEntityAdapter, createSelector, createSlice } from '@reduxjs/toolkit';
 
 import { RootState } from './store';
@@ -48,7 +48,7 @@ const scoresSlice = createSlice({
                     scores[round] += Number(multiplier);
                 } catch (error) {
                     const err = error as Error;
-                    crashlytics().recordError(err);
+                    recordError(getCrashlytics(), err);
                 }
             },
             prepare(payload: string, round: RoundIndex, multiplier: number) {
@@ -65,7 +65,7 @@ const scoresSlice = createSlice({
                     scores[action.meta.round] = action.meta.value;
                 } catch (error) {
                     const err = error as Error;
-                    crashlytics().recordError(err);
+                    recordError(getCrashlytics(), err);
                 }
             },
             prepare(payload: string, round: RoundIndex, value: number) {

--- a/src/Analytics.ts
+++ b/src/Analytics.ts
@@ -11,8 +11,11 @@ import logger from './Logger';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const logEvent = async (eventName: string, params?: Record<string, any>) => {
+    const appVersion = Application.nativeApplicationVersion;
+    const buildNumber = Application.nativeBuildVersion;
+
     if (process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS == 'false') {
-        logger.info('\x1b[34m', 'EVENT', eventName, JSON.stringify(params ?? {}, null, 2), '\x1b[0m');
+        logger.info('\x1b[34m', 'EVENT', eventName, JSON.stringify({ ...params, appVersion, buildNumber }, null, 2), '\x1b[0m');
         return;
     }
 
@@ -21,7 +24,6 @@ export const logEvent = async (eventName: string, params?: Record<string, any>) 
     const sessionId = await getSessionId(analytics);
     const os = Platform.OS;
     const osVersion = Platform.Version;
-    const appVersion = Application.nativeApplicationVersion;
 
     const fullParams = Object.fromEntries(
         Object.entries({
@@ -30,6 +32,7 @@ export const logEvent = async (eventName: string, params?: Record<string, any>) 
             sessionId,
             os,
             appVersion,
+            buildNumber,
             osVersion,
         }).filter(([, v]) => v != null && v !== undefined),
     );

--- a/src/Analytics.ts
+++ b/src/Analytics.ts
@@ -11,6 +11,11 @@ import logger from './Logger';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const logEvent = async (eventName: string, params?: Record<string, any>) => {
+    if (process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS == 'false') {
+        logger.info('\x1b[34m', 'EVENT', eventName, JSON.stringify(params ?? {}, null, 2), '\x1b[0m');
+        return;
+    }
+
     const analytics = getAnalytics();
     const appInstanceId = await getAppInstanceId(analytics);
     const sessionId = await getSessionId(analytics);
@@ -18,29 +23,24 @@ export const logEvent = async (eventName: string, params?: Record<string, any>) 
     const osVersion = Platform.Version;
     const appVersion = Application.nativeApplicationVersion;
 
-    const sanitized = Object.fromEntries(
-        Object.entries({ ...params }).filter(
-            ([, v]) => v != null && v !== undefined,
-        ),
+    const fullParams = Object.fromEntries(
+        Object.entries({
+            ...params,
+            appInstanceId,
+            sessionId,
+            os,
+            appVersion,
+            osVersion,
+        }).filter(([, v]) => v != null && v !== undefined),
     );
 
-    const fullParams = {
-        ...sanitized,
-        appInstanceId,
-        sessionId,
-        os,
-        appVersion,
-        osVersion,
-    };
-
     logger.info(
-        '\x1b[34m', // Set the color to blue
+        '\x1b[34m',
         'EVENT',
         eventName,
         JSON.stringify(fullParams, null, 2),
-        '\x1b[0m' // Reset the color
+        '\x1b[0m'
     );
 
-    // Log the event to Firebase Analytics
     await firebaseLogEvent(analytics, eventName, fullParams);
 };


### PR DESCRIPTION
## Summary

- Migrate `analytics()` and `crashlytics()` namespaced calls to the modular API (`getAnalytics`, `setAnalyticsCollectionEnabled`, `getCrashlytics`, `recordError`) to silence runtime deprecation warnings
- Fix `nil` value crash in Firebase Analytics by sanitizing all enriched params (not just caller-provided params) before sending
- Guard against "Analytics uninitialized" error on dev client by skipping Firebase SDK calls when `EXPO_PUBLIC_FIREBASE_ANALYTICS=false`, while still logging events to console
- Add `buildNumber` (`nativeBuildVersion`) to all analytics events

## Test plan

- [ ] Confirm no "deprecated namespaced API" warnings in logs
- [ ] Confirm no "Analytics uninitialized" error in dev client logs
- [ ] Confirm events still appear in dev console with event name, params, appVersion, and buildNumber
- [ ] Trigger a score change to confirm crashlytics path runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)