### PR TITLE
perf: fix makeSelectPlayerColors() called on every render

### DIFF
--- a/src/components/Boards/FlexboxTile.tsx
+++ b/src/components/Boards/FlexboxTile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { DimensionValue, StyleSheet } from 'react-native';
 import Animated, { Easing, FadeIn } from 'react-native-reanimated';
@@ -39,7 +39,7 @@ const FlexboxTile: React.FunctionComponent<Props> = React.memo(({
     const currentGame = useAppSelector(selectCurrentGame);
     const currentGameId = currentGame?.id;
     const playerIndexLabel = useAppSelector(state => state.settings.showPlayerIndex);
-    const selectPlayerColors = makeSelectPlayerColors();
+    const selectPlayerColors = useMemo(() => makeSelectPlayerColors(), []);
     const playerColors = useAppSelector(state => selectPlayerColors(state, currentGameId, playerId));
     const [bg, fg] = playerColors;
     const isWinner = !!(currentGame?.locked && currentGame?.winnerIds?.includes(playerId));

--- a/src/components/PlayerListItem.tsx
+++ b/src/components/PlayerListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -33,7 +33,7 @@ const PlayerListItem: React.FunctionComponent<Props> = ({
     const currentGameId = useAppSelector(state => selectCurrentGame(state)?.id);
     const playerIds = useAppSelector(state => selectGameById(state, currentGameId || '')?.playerIds);
     const player = useAppSelector(state => selectPlayerById(state, playerId));
-    const selectPlayerColors = makeSelectPlayerColors();
+    const selectPlayerColors = useMemo(() => makeSelectPlayerColors(), []);
     const playerColors = useAppSelector(state => selectPlayerColors(state, currentGameId, playerId));
     const dispatch = useAppDispatch();
 

--- a/src/components/ScoreLog/PlayerNameColumn.tsx
+++ b/src/components/ScoreLog/PlayerNameColumn.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements/dist/icons/Icon';
@@ -19,7 +19,7 @@ interface CellProps {
 
 const PlayerNameCell: React.FunctionComponent<CellProps> = ({ index, playerId }) => {
     const theme = useTheme();
-    const selectPlayerColors = makeSelectPlayerColors();
+    const selectPlayerColors = useMemo(() => makeSelectPlayerColors(), []);
     const currentGameId = useAppSelector(state => selectCurrentGame(state)?.id);
     const playerColors = useAppSelector(state => selectPlayerColors(state, currentGameId, playerId));
     const playerName = useAppSelector(state => selectPlayerById(state, playerId)?.playerName);


### PR DESCRIPTION
## Summary

- `makeSelectPlayerColors()` is a Redux Toolkit selector factory — it must be instantiated **once per component instance** to benefit from memoization
- All three affected components called it directly in the render body, creating a fresh selector instance on every render and defeating the cache entirely
- Fix: wrap each call in `useMemo(() => makeSelectPlayerColors(), [])` so the selector is stable for the component's lifetime

## Files changed

- `src/components/Boards/FlexboxTile.tsx`
- `src/components/ScoreLog/PlayerNameColumn.tsx` (inside `PlayerNameCell`)
- `src/components/PlayerListItem.tsx`

## Test plan

- [x] Game board tiles render correct player colors
- [x] Score log player name column shows correct color accents
- [x] Player list in Settings shows correct color badges
- [ ] No unnecessary re-renders when unrelated state changes (verify with React DevTools Profiler)

https://claude.ai/code/session_01GEbd7KUANzXX4gLe7BmN9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEbd7KUANzXX4gLe7BmN9Y)_