### PR TITLE
fix(android): fix icon visibility and flatten options menu

### DIFF
--- a/src/components/Buttons/GameOptionsButton.tsx
+++ b/src/components/Buttons/GameOptionsButton.tsx
@@ -47,66 +47,72 @@ const GameOptionsButton: React.FunctionComponent = () => {
             ? `Spin: ${addendOne} / Hold: ${addendTwo}`
             : `Swipe: ${addendOne} / Hold: ${addendTwo}`;
 
-    const menuActions: MenuAction[] = [
+    const gestureActions: MenuAction[] = [
         {
-            id: 'gestures',
-            title: 'Point Gestures',
-            displayInline: true,
-            subactions: [
-                {
-                    id: 'swipe',
-                    title: 'Swipe',
-                    image: 'hand.draw',
-                    imageColor: theme.text,
-                    state: isSwipe ? 'on' : 'off',
-                },
-                {
-                    id: 'tap',
-                    title: 'Tap',
-                    image: 'hand.point.up',
-                    imageColor: theme.text,
-                    state: isTap ? 'on' : 'off',
-                },
-                {
-                    id: 'dial',
-                    title: 'Dial',
-                    subtitle: showDialDot ? 'New' : undefined,
-                    image: 'dial.min',
-                    imageColor: theme.text,
-                    state: isDial ? 'on' : 'off',
-                },
-                {
-                    id: 'about-gestures',
-                    title: 'About Gestures',
-                    image: 'info.circle',
-                    imageColor: theme.text,
-                },
-            ],
+            id: 'swipe',
+            title: 'Swipe',
+            image: 'hand.draw',
+            imageColor: theme.text,
+            state: isSwipe ? 'on' : 'off',
         },
         {
-            id: 'settings',
-            title: 'Settings',
-            displayInline: true,
-            subactions: [
-                {
-                    id: 'point-values',
-                    title: 'Point Values',
-                    subtitle: pointValuesSubtitle,
-                    image: 'plusminus',
-                    imageColor: theme.text,
-                },
-                {
-                    id: 'fullscreen',
-                    title: 'Fullscreen',
-                    image: fullscreen
-                        ? 'arrow.down.right.and.arrow.up.left'
-                        : 'arrow.up.left.and.arrow.down.right',
-                    imageColor: theme.text,
-                    state: fullscreen ? 'on' : 'off',
-                },
-            ],
+            id: 'tap',
+            title: 'Tap',
+            image: 'hand.point.up',
+            imageColor: theme.text,
+            state: isTap ? 'on' : 'off',
+        },
+        {
+            id: 'dial',
+            title: 'Dial',
+            subtitle: showDialDot ? 'New' : undefined,
+            image: 'dial.min',
+            imageColor: theme.text,
+            state: isDial ? 'on' : 'off',
+        },
+        {
+            id: 'about-gestures',
+            title: 'About Gestures',
+            image: 'info.circle',
+            imageColor: theme.text,
         },
     ];
+
+    const settingsActions: MenuAction[] = [
+        {
+            id: 'point-values',
+            title: 'Point Values',
+            subtitle: pointValuesSubtitle,
+            image: 'plusminus',
+            imageColor: theme.text,
+        },
+        {
+            id: 'fullscreen',
+            title: 'Fullscreen',
+            image: fullscreen
+                ? 'arrow.down.right.and.arrow.up.left'
+                : 'arrow.up.left.and.arrow.down.right',
+            imageColor: theme.text,
+            state: fullscreen ? 'on' : 'off',
+        },
+    ];
+
+    const menuActions: MenuAction[] = Platform.OS === 'android'
+        ? [...gestureActions, ...settingsActions]
+        : [
+            {
+                id: 'gestures',
+                title: 'Point Gestures',
+                displayInline: true,
+                subactions: gestureActions,
+            },
+            {
+                id: 'settings',
+                title: 'Settings',
+                displayInline: true,
+                subactions: settingsActions,
+            },
+        ];
 
     const handleAction = (event: string) => {
         switch (event) {

--- a/src/components/Buttons/GameOptionsButton.tsx
+++ b/src/components/Buttons/GameOptionsButton.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { MenuAction, MenuView } from '@react-native-menu/menu';
 import { SymbolView } from 'expo-symbols';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text, Platform } from 'react-native';
 
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { toggleHomeFullscreen, setInteractionType, markFeatureNotificationSeen } from '../../../redux/SettingsSlice';
@@ -158,11 +159,19 @@ const GameOptionsButton: React.FunctionComponent = () => {
                         <Text style={[styles.addendText, { color: theme.text }]}>{addendTwo}</Text>
                     </View>
                     <View>
-                        <SymbolView
-                            name={isDial ? 'dial.min' : isSwipe ? 'hand.draw' : 'hand.point.up'}
-                            size={30}
-                            tintColor={theme.text}
-                        />
+                        {Platform.OS === 'ios' ? (
+                            <SymbolView
+                                name={isDial ? 'dial.min' : isSwipe ? 'hand.draw' : 'hand.point.up'}
+                                size={30}
+                                tintColor={theme.text}
+                            />
+                        ) : (
+                            <MaterialCommunityIcons
+                                name={isDial ? 'knob' : isSwipe ? 'gesture-swipe-up' : 'gesture-tap'}
+                                size={30}
+                                color={theme.text}
+                            />
+                        )}
                         {showDialDot && (
                             <View testID="dial-notification-dot" style={{
                                 position: 'absolute',


### PR DESCRIPTION
## Summary

| Menu | Dial | Tap | Swipe |
|-----|--------|--------|--------|
| <img width="1080" height="2424" alt="Screenshot_1780721583" src="https://github.com/user-attachments/assets/e799fdd4-8b1c-45cf-a01b-6778051d5fcf" /> | <img width="1080" height="2424" alt="Screenshot_1780721354" src="https://github.com/user-attachments/assets/bd36ac5e-e8cc-409f-aeeb-7fd2a7d44714" /> | <img width="1080" height="2424" alt="Screenshot_1780721351" src="https://github.com/user-attachments/assets/b11fc414-8f9c-4fea-ba82-8c1dbd14488a" /> | <img width="1080" height="2424" alt="Screenshot_1780721347" src="https://github.com/user-attachments/assets/46893da6-5ceb-4279-a22e-5e614f1a634c" /> | 

- **Icon not visible on Android**: `SymbolView` from `expo-symbols` is iOS-only and renders nothing on Android. Now falls back to `MaterialCommunityIcons` (`knob` / `gesture-swipe-up` / `gesture-tap`) so the interaction icon is visible next to the addends on Android.
- **Extra tap required on Android**: `@react-native-menu/menu` renders grouped `subactions` as nested menus on Android, requiring an extra tap to expand each section. The menu actions are now extracted into shared `gestureActions` and `settingsActions` arrays — on Android they are spread into a flat top-level list, while iOS keeps the existing grouped/inline structure.

## Test plan

- [x] On Android: verify the interaction icon (dial/swipe/tap) appears in the game options button next to the addends
- [x] On Android: tap the game options menu and verify all items (Swipe, Tap, Dial, About Gestures, Point Values, Fullscreen) appear in a single flat list without needing to tap a section heading first
- [x] On iOS: verify the menu still shows the two grouped sections (Point Gestures / Settings) inline as before
- [x] On iOS: verify the interaction icon still renders correctly via `SymbolView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)