### PR TITLE
perf: combined callbacks, memo, and selector fixes

### DIFF
--- a/src/components/Boards/FlexboxBoard.tsx
+++ b/src/components/Boards/FlexboxBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 
 import { LayoutChangeEvent, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -120,4 +120,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default FlexboxBoard;
+export default memo(FlexboxBoard);

--- a/src/components/Boards/FlexboxTile.tsx
+++ b/src/components/Boards/FlexboxTile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { DimensionValue, StyleSheet } from 'react-native';
 import Animated, { Easing, FadeIn } from 'react-native-reanimated';
@@ -39,7 +39,7 @@ const FlexboxTile: React.FunctionComponent<Props> = React.memo(({
     const currentGame = useAppSelector(selectCurrentGame);
     const currentGameId = currentGame?.id;
     const playerIndexLabel = useAppSelector(state => state.settings.showPlayerIndex);
-    const selectPlayerColors = makeSelectPlayerColors();
+    const selectPlayerColors = useMemo(() => makeSelectPlayerColors(), []);
     const playerColors = useAppSelector(state => selectPlayerColors(state, currentGameId, playerId));
     const [bg, fg] = playerColors;
     const isWinner = !!(currentGame?.locked && currentGame?.winnerIds?.includes(playerId));

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -114,4 +114,4 @@ const styles = StyleSheet.create({
     }
 });
 
-export default GameListItem;
+export default memo(GameListItem);

--- a/src/components/PlayerListItem.tsx
+++ b/src/components/PlayerListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -33,7 +33,7 @@ const PlayerListItem: React.FunctionComponent<Props> = ({
     const currentGameId = useAppSelector(state => selectCurrentGame(state)?.id);
     const playerIds = useAppSelector(state => selectGameById(state, currentGameId || '')?.playerIds);
     const player = useAppSelector(state => selectPlayerById(state, playerId));
-    const selectPlayerColors = makeSelectPlayerColors();
+    const selectPlayerColors = useMemo(() => makeSelectPlayerColors(), []);
     const playerColors = useAppSelector(state => selectPlayerColors(state, currentGameId, playerId));
     const dispatch = useAppDispatch();
 

--- a/src/components/PlayerListItem.tsx
+++ b/src/components/PlayerListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -161,4 +161,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default PlayerListItem;
+export default memo(PlayerListItem);

--- a/src/components/Rounds.tsx
+++ b/src/components/Rounds.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -105,4 +105,4 @@ const styles = StyleSheet.create({
     }
 });
 
-export default Rounds;
+export default memo(Rounds);

--- a/src/components/Rounds.tsx
+++ b/src/components/Rounds.tsx
@@ -40,10 +40,10 @@ const Rounds: React.FunctionComponent<Props> = ({ }) => {
     const onLayoutHandler = useCallback((event: LayoutChangeEvent, round: number) => {
         const offset = event.nativeEvent.layout.x;
 
-        setRoundScrollOffset({
-            ...roundScollOffset,
+        setRoundScrollOffset(prev => ({
+            ...prev,
             [round]: offset
-        });
+        }));
     }, []);
 
     // Scroll to the current round
@@ -61,15 +61,15 @@ const Rounds: React.FunctionComponent<Props> = ({ }) => {
 
     const dispatch = useAppDispatch();
 
-    const sortByPlayerIndex = () => {
+    const sortByPlayerIndex = useCallback(() => {
         dispatch(setSortSelector({ gameId: currentGameId, sortSelector: SortSelectorKey.ByIndex }));
         logEvent('sort_by_index', { gameId: currentGameId });
-    };
+    }, [dispatch, currentGameId]);
 
-    const sortByTotalScore = () => {
+    const sortByTotalScore = useCallback(() => {
         dispatch(setSortSelector({ gameId: currentGameId, sortSelector: SortSelectorKey.ByScore }));
         logEvent('sort_by_score', { gameId: currentGameId });
-    };
+    }, [dispatch, currentGameId]);
 
     return (
         <View style={[styles.scoreTableContainer]}>

--- a/src/components/ScoreLog/PlayerNameColumn.tsx
+++ b/src/components/ScoreLog/PlayerNameColumn.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements/dist/icons/Icon';
@@ -19,7 +19,7 @@ interface CellProps {
 
 const PlayerNameCell: React.FunctionComponent<CellProps> = ({ index, playerId }) => {
     const theme = useTheme();
-    const selectPlayerColors = makeSelectPlayerColors();
+    const selectPlayerColors = useMemo(() => makeSelectPlayerColors(), []);
     const currentGameId = useAppSelector(state => selectCurrentGame(state)?.id);
     const playerColors = useAppSelector(state => selectPlayerColors(state, currentGameId, playerId));
     const playerName = useAppSelector(state => selectPlayerById(state, playerId)?.playerName);

--- a/src/components/ScoreLog/PlayerNameColumn.tsx
+++ b/src/components/ScoreLog/PlayerNameColumn.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import { StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements/dist/icons/Icon';
@@ -84,4 +84,4 @@ const styles = StyleSheet.create({
     }
 });
 
-export default PlayerNameColumn;
+export default memo(PlayerNameColumn);

--- a/src/components/ScoreLog/TotalScoreColumn.tsx
+++ b/src/components/ScoreLog/TotalScoreColumn.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -44,4 +44,4 @@ const styles = StyleSheet.create({
     }
 });
 
-export default TotalScoreColumn;
+export default memo(TotalScoreColumn);


### PR DESCRIPTION
## Summary

Combines three performance branches for integrated testing before merging individually to main:

- **perf/fix-rounds-callbacks** — #616 — stabilizes callbacks in Rounds components
- **perf/memo-list-items** — #614 — adds `React.memo` to list item components
- **perf/fix-selector-memoization** — #613 — fixes selector memoization in ScoreLog

## Files changed

- `src/components/Rounds.tsx` — callback fixes
- `src/components/Boards/FlexboxBoard.tsx`, `FlexboxTile.tsx` — memo/callback fixes
- `src/components/PlayerListItem.tsx`, `GameListItem.tsx` — list item memoization
- `src/components/ScoreLog/PlayerNameColumn.tsx`, `TotalScoreColumn.tsx` — selector memoization

## Notes

- Conflict in `PlayerNameColumn.tsx` resolved by combining `memo` and `useMemo` imports (both needed)
- This branch is for combined testing only — each PR should merge to main independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)