### PR TITLE
Fix Android share image flow

### DIFF
--- a/src/components/Sheets/GameSheet.test.tsx
+++ b/src/components/Sheets/GameSheet.test.tsx
@@ -372,6 +372,34 @@ describe('GameSheet', () => {
         expect(getByTestId('choose-winners-button')).toBeTruthy();
     });
 
+    it('should navigate to Share when share button is pressed', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: mockPlayers,
+                ids: ['player-1', 'player-2'],
+            },
+        });
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <GameSheet {...defaultProps} />
+            </Provider>
+        );
+
+        fireEvent.press(getByTestId('share-button'));
+
+        expect(mockNavigate).toHaveBeenCalledWith('Share');
+    });
+
     it('should toggle lock when unlock button is pressed', async () => {
         const lockedGame = { ...mockGame, locked: true };
         const store = createMockStore({

--- a/src/components/Sheets/GameSheet.tsx
+++ b/src/components/Sheets/GameSheet.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { ParamListBase, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Alert, Platform, StyleSheet, Text, TouchableWithoutFeedback, View, useWindowDimensions } from 'react-native';
+import { Alert, StyleSheet, Text, TouchableWithoutFeedback, View, useWindowDimensions } from 'react-native';
 import { Button } from 'react-native-elements';
 import Animated, { Extrapolate, FadeIn, interpolate, Layout, useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -301,13 +301,12 @@ const GameSheet: React.FunctionComponent = () => {
                         </Animated.View>
 
                         <Animated.View key={mountKey + 'a'} layout={Layout.delay(200)} style={{ flexDirection: 'row', justifyContent: 'space-around', paddingVertical: 10 }}>
-                            {Platform.OS === 'ios' &&
-                                <BigButton text="Share"
-                                    color={theme.tint}
-                                    icon="share-outline"
-                                    onPress={() => navigation.navigate('Share')}
-                                />
-                            }
+                            <BigButton text="Share"
+                                color={theme.tint}
+                                icon="share-outline"
+                                onPress={() => navigation.navigate('Share')}
+                                testID="share-button"
+                            />
 
                             <BigButton text={gameLocked ? 'Unlock' : 'Choose Winners'}
                                 color={gameLocked ? theme.warning : theme.success}

--- a/src/screens/ShareScreen.test.tsx
+++ b/src/screens/ShareScreen.test.tsx
@@ -17,6 +17,13 @@ import ShareScreen from './ShareScreen';
 jest.mock('expo-sharing');
 jest.mock('react-native-view-shot');
 jest.mock('../Analytics');
+jest.mock('react-native-safe-area-context', () => ({
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => {
+        const { View } = jest.requireActual('react-native');
+        return <View>{children}</View>;
+    },
+    useSafeAreaInsets: jest.fn(() => ({ top: 0, bottom: 34, left: 0, right: 0 })),
+}));
 jest.mock('expo-font', () => ({
     isLoaded: () => true,
     loadAsync: () => Promise.resolve(),
@@ -200,6 +207,34 @@ describe('ShareScreen', () => {
         expect(getByTestId('total-score-column')).toBeTruthy();
     });
 
+    it('should add bottom scroll padding below the share button', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: mockPlayers,
+                ids: ['player-1', 'player-2'],
+            },
+        });
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <ShareScreen navigation={mockNavigation} />
+            </Provider>
+        );
+
+        expect(getByTestId('share-screen-scroll').props.contentContainerStyle).toEqual({
+            paddingBottom: 114,
+        });
+    });
+
     it('should render correct number of round columns based on roundTotal', () => {
         const store = createMockStore({
             settings: {
@@ -300,7 +335,7 @@ describe('ShareScreen', () => {
                     result: 'tmpfile',
                     quality: 1,
                     format: 'png',
-                    snapshotContentContainer: true,
+                    fileName: undefined,
                 }
             );
         });

--- a/src/screens/ShareScreen.tsx
+++ b/src/screens/ShareScreen.tsx
@@ -3,9 +3,9 @@ import React, { useRef } from 'react';
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import * as Sharing from 'expo-sharing';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Button, Icon } from 'react-native-elements';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { captureRef } from 'react-native-view-shot';
 
 import { selectGameById } from '../../redux/GamesSlice';
@@ -23,6 +23,7 @@ interface Props {
 
 const ShareScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     const theme = useTheme();
+    const insets = useSafeAreaInsets();
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
     if (typeof currentGameId == 'undefined') return null;
 
@@ -30,19 +31,19 @@ const ShareScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     const currentGame = useAppSelector(selectCurrentGame);
     if (typeof currentGame == 'undefined') return null;
 
-    const roundsScrollViewEl = useRef<ScrollView>(null);
+    const scoreboardImageEl = useRef<View>(null);
 
     const roundsIterator = [...Array(roundTotal).keys()];
 
     const exportImage = async () => {
-        if (roundsScrollViewEl.current == null) return;
+        if (scoreboardImageEl.current == null) return;
 
         try {
-            const uri = await captureRef(roundsScrollViewEl, {
+            const uri = await captureRef(scoreboardImageEl.current, {
                 result: 'tmpfile',
                 quality: 1,
                 format: 'png',
-                snapshotContentContainer: true,
+                fileName: Platform.OS === 'android' ? 'scorepad-scoreboard' : undefined,
             });
 
             await Sharing.shareAsync(uri, {
@@ -60,7 +61,9 @@ const ShareScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     return (
         <SafeAreaView edges={['right', 'left']}
             style={[styles.contentContainer, { backgroundColor: theme.background }]}>
-            <ScrollView>
+            <ScrollView
+                testID="share-screen-scroll"
+                contentContainerStyle={{ paddingBottom: insets.bottom + 80 }}>
 
                 <Text style={{ color: theme.text, paddingVertical: 20 }}>
                     You can edit the game title or player names before sharing.
@@ -85,31 +88,38 @@ const ShareScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                         contentContainerStyle={{
                             backgroundColor: theme.background,
                             flexDirection: 'column',
-                            padding: 20,
-                        }}
-                        ref={roundsScrollViewEl}>
-                        <View style={{ flexDirection: 'column' }}>
-                            <Text style={{ color: theme.text, fontSize: 20, fontWeight: 'bold', paddingBottom: 10 }}>
-                                {currentGame?.title}
-                            </Text>
-                            <Text style={{ color: theme.text }}>
-                                Created: {new Date(currentGame.dateCreated).toLocaleDateString()}
-                                &nbsp; {new Date(currentGame.dateCreated).toLocaleTimeString()}
-                            </Text>
-                        </View>
-                        <View style={{ flexDirection: 'row' }}>
-                            <PlayerNameColumn />
-                            <TotalScoreColumn />
-                            {roundsIterator.map((item, round) => (
-                                <View key={round}>
-                                    <RoundScoreColumn
-                                        round={round}
-                                        key={round}
-                                        isCurrentRound={false}
-                                        disabled={true}
-                                    />
-                                </View>
-                            ))}
+                        }}>
+                        <View
+                            collapsable={false}
+                            ref={scoreboardImageEl}
+                            style={{
+                                backgroundColor: theme.background,
+                                flexDirection: 'column',
+                                padding: 20,
+                            }}>
+                            <View style={{ flexDirection: 'column' }}>
+                                <Text style={{ color: theme.text, fontSize: 20, fontWeight: 'bold', paddingBottom: 10 }}>
+                                    {currentGame?.title}
+                                </Text>
+                                <Text style={{ color: theme.text }}>
+                                    Created: {new Date(currentGame.dateCreated).toLocaleDateString()}
+                                    &nbsp; {new Date(currentGame.dateCreated).toLocaleTimeString()}
+                                </Text>
+                            </View>
+                            <View style={{ flexDirection: 'row' }}>
+                                <PlayerNameColumn />
+                                <TotalScoreColumn />
+                                {roundsIterator.map((item, round) => (
+                                    <View key={round}>
+                                        <RoundScoreColumn
+                                            round={round}
+                                            key={round}
+                                            isCurrentRound={false}
+                                            disabled={true}
+                                        />
+                                    </View>
+                                ))}
+                            </View>
                         </View>
                     </ScrollView>
                 </View>


### PR DESCRIPTION
## Summary

- Fix Android "Share as image" capture by snapshotting a dedicated non-collapsible scoreboard view instead of the horizontal ScrollView wrapper.
- Add an Android capture filename prefix so the temporary PNG has clearer image metadata when handed to the native share sheet.
- Add bottom scroll padding on the Share screen using the safe-area bottom inset plus extra spacing, so the "Share as image" button can scroll above the Android gesture handle.
- Enable the Game Sheet Share button on Android by removing the iOS-only platform guard.
- Add regression coverage for Share screen bottom padding and Game Sheet Share navigation.

## Verification

- `npm run lint`
- `npm run test -- --runInBand --no-watchman`

Full suite result: 33 test suites passed, 311 tests passed.
