### PR TITLE
Fix Android list header overlap

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { useAppSelector } from '../redux/hooks';
 import AppInfoButton from '../src/components/Buttons/AppInfoButton';
@@ -40,6 +40,11 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export const Navigation = () => {
     const theme = useTheme();
+    const isAndroid = Platform.OS === 'android';
+    const isIOS = Platform.OS === 'ios';
+    const listHeaderStyle = isAndroid
+        ? { backgroundColor: theme.backgroundSecondary }
+        : undefined;
     const isDark = theme.background === '#000000';
     const navTheme = isDark
         ? { ...DarkTheme, colors: { ...DarkTheme.colors, background: theme.background, card: theme.background } }
@@ -66,9 +71,10 @@ export const Navigation = () => {
                             options={{
                                 orientation: 'portrait',
                                 title: 'ScorePad',
-                                headerTransparent: true,
-                                headerBlurEffect: 'systemChromeMaterial',
-                                headerShadowVisible: false,
+                                headerTransparent: isIOS,
+                                headerBlurEffect: isIOS ? 'systemChromeMaterial' : undefined,
+                                headerShadowVisible: isAndroid,
+                                headerStyle: listHeaderStyle,
                                 headerLeft: () => <AppInfoButton />,
                             }}
                         />

--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -4,7 +4,7 @@ import { useHeaderHeight } from '@react-navigation/elements';
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import * as Crypto from 'expo-crypto';
-import { StyleSheet, Text } from 'react-native';
+import { Platform, StyleSheet, Text } from 'react-native';
 import Animated, { Easing, LinearTransition } from 'react-native-reanimated';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -30,6 +30,7 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
 
     const rollingGameCounter = useAppSelector(state => state.settings.rollingGameCounter);
     const headerHeight = useHeaderHeight();
+    const listHeaderInset = Platform.OS === 'ios' ? headerHeight : 0;
     const insets = useSafeAreaInsets();
 
     useEffect(() => {
@@ -58,9 +59,9 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         <SafeAreaView edges={['left', 'right']} style={{ backgroundColor: theme.backgroundSecondary, flex: 1 }} testID="home-screen">
             <Animated.FlatList
                 alwaysBounceVertical
-                contentContainerStyle={{ flexGrow: 1, paddingTop: headerHeight, paddingBottom: insets.bottom + 70 }}
+                contentContainerStyle={{ flexGrow: 1, paddingTop: listHeaderInset, paddingBottom: insets.bottom + 70 }}
                 contentInsetAdjustmentBehavior="never"
-                scrollIndicatorInsets={{ top: headerHeight, bottom: insets.bottom + 70 }}
+                scrollIndicatorInsets={{ top: listHeaderInset, bottom: insets.bottom + 70 }}
                 itemLayoutAnimation={LinearTransition.easing(Easing.ease)}
                 ListEmptyComponent={
                     <>


### PR DESCRIPTION
## Summary
- keep the home list header transparent/blurred on iOS only
- give Android an opaque themed header with native shadow
- remove the extra top list inset on Android while preserving iOS spacing

## Test
- npm run lint