### PR TITLE
Defer dial score commits until gesture end

### DIFF
--- a/redux/PlayersSlice.test.ts
+++ b/redux/PlayersSlice.test.ts
@@ -3,6 +3,7 @@ import playersReducer, {
     removePlayer,
     playerAdd,
     playerRoundScoreIncrement,
+    playerRoundScoreSet,
 } from '../redux/PlayersSlice';
 
 describe('players reducer', () => {
@@ -93,5 +94,15 @@ describe('players reducer', () => {
         }
         expect(actual.entities['1'].scores[3]).toEqual(10);
         expect(actual.entities['1'].scores[0]).toEqual(10);
+    });
+
+    it('should not change state when setting a round score to the current value', () => {
+        const actual = playersReducer(initialState, playerAdd({
+            id: '1',
+            playerName: 'Test',
+            scores: [10, 20, 30],
+        }));
+        const next = playersReducer(actual, playerRoundScoreSet('1', 1, 20));
+        expect(next).toBe(actual);
     });
 });

--- a/redux/PlayersSlice.ts
+++ b/redux/PlayersSlice.ts
@@ -62,6 +62,7 @@ const scoresSlice = createSlice({
             ) {
                 try {
                     const scores = state?.entities[action.payload]?.scores || [];
+                    if (scores[action.meta.round] === action.meta.value) return;
                     scores[action.meta.round] = action.meta.value;
                 } catch (error) {
                     const err = error as Error;

--- a/src/components/Interactions/Dial/DialControl.test.tsx
+++ b/src/components/Interactions/Dial/DialControl.test.tsx
@@ -73,7 +73,7 @@ jest.mock('expo-haptics', () => ({
     ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
 }));
 
-import DialControl from './DialControl';
+import DialControl, { getCenterValueFontScale } from './DialControl';
 
 // Creates a mock SharedValue matching the shape returned by the Reanimated mock
 const mkSv = <T,>(v: T) => ({ value: v }) as unknown as SharedValue<T>;
@@ -93,6 +93,22 @@ const defaultProps = {
 beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
+});
+
+describe('getCenterValueFontScale', () => {
+    it('keeps short signed values at full size', () => {
+        expect(getCenterValueFontScale(5)).toBe(1);
+        expect(getCenterValueFontScale(-3)).toBe(1);
+        expect(getCenterValueFontScale(999)).toBe(1);
+    });
+
+    it('shrinks positive four-digit values so the sign and digits fit', () => {
+        expect(getCenterValueFontScale(1000)).toBeLessThan(1);
+    });
+
+    it('does not shrink below the minimum scale for very long values', () => {
+        expect(getCenterValueFontScale(123456789)).toBe(0.62);
+    });
 });
 
 describe('DialControl — rendering', () => {

--- a/src/components/Interactions/Dial/DialControl.tsx
+++ b/src/components/Interactions/Dial/DialControl.tsx
@@ -18,7 +18,11 @@ import Animated, {
 import Svg, { Circle, Line, Path } from 'react-native-svg';
 
 // Extend TextInputProps to include Reanimated's animated text content prop
-type AnimatedTextInputProps = TextInputProps & { text?: string };
+type AnimatedTextInputProps = TextInputProps & {
+    text?: string;
+    adjustsFontSizeToFit?: boolean;
+    minimumFontScale?: number;
+};
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput as React.ComponentType<AnimatedTextInputProps>);
 
 import { POWER_HOLD_ACTIVATION_MS, POWER_HOLD_INDICATOR_DELAY_MS } from '../interactionConstants';
@@ -147,6 +151,12 @@ const DialControl: React.FC<Props> = ({
     const svStartY = useSharedValue(0);
     const svHasMoved = useSharedValue(false);
     const svStartValue = useSharedValue(0);
+    // Optimistic drag state: update visible shared values during the gesture,
+    // then commit only the final pending score to Redux once the gesture closes.
+    const svStartNewTotal = useSharedValue(0);
+    const svPendingValue = useSharedValue(0);
+    const svLastStep = useSharedValue(0);
+    const svDidFlush = useSharedValue(true);
 
     useEffect(() => { svInc.value = isSecondary ? addendTwo : addendOne; }, [isSecondary, addendOne, addendTwo]);
 
@@ -218,13 +228,10 @@ const DialControl: React.FC<Props> = ({
         holdProgress.value = withTiming(0, { duration: 200, easing: Easing.out(Easing.cubic) });
     }, []);
 
-    const handleBump = useCallback((newVal: number) => {
-        if (newVal !== svValue.value) {
-            onChange(newVal);
-            if (isSecondaryRef.current) popNumber();
-            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-        }
-    }, [onChange, svValue, popNumber]);
+    const handleBumpFeedback = useCallback(() => {
+        if (isSecondaryRef.current) popNumber();
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    }, [popNumber]);
 
     const centerValueAnimProps = useAnimatedProps(() => ({
         text: fmtSigned(svValue.value),
@@ -283,15 +290,24 @@ const DialControl: React.FC<Props> = ({
         onToggleMode(false);
     }, [onToggleMode]);
 
+    const flushPendingChange = useCallback((newVal: number) => {
+        onChange(newVal);
+    }, [onChange]);
+
     const panGesture = Gesture.Pan()
         .enabled(!menuOpen)
         .minDistance(0)
         .onBegin((e) => {
-            svStartValue.value = svValue.value;
-            svAccDeg.value = 0;
-            svHasMoved.value = false;
-            svStartX.value = e.x;
-            svStartY.value = e.y;
+            svStartValue.value = svValue.value; // round score at gesture start, before optimistic dial updates
+            // Capture the gesture baseline so live total = start total + round delta.
+            svStartNewTotal.value = svNewTotal.value; // total score at gesture start, before optimistic dial updates
+            svPendingValue.value = svValue.value; // latest optimistic round score waiting to be flushed to Redux
+            svLastStep.value = 0; // last emitted notch offset from svStartValue
+            svDidFlush.value = false; // reset one-shot guard for the eventual Redux flush
+            svAccDeg.value = 0; // accumulated rotation degrees since gesture start
+            svHasMoved.value = false; // long-press hold is still possible until movement passes threshold
+            svStartX.value = e.x; // touch start x, used to detect movement beyond hold threshold
+            svStartY.value = e.y; // touch start y, used to detect movement beyond hold threshold
 
             const dx = e.x - C;
             const dy = e.y - C;
@@ -319,16 +335,36 @@ const DialControl: React.FC<Props> = ({
             svLastAngle.value = angle;
 
             const steps = Math.round(svAccDeg.value / STEP_DEG);
+            if (steps === svLastStep.value) return;
+
+            svLastStep.value = steps;
             const newVal = svStartValue.value + steps * svInc.value;
-            runOnJS(handleBump)(newVal);
+            svPendingValue.value = newVal;
+            svValue.value = newVal;
+            svNewTotal.value = svStartNewTotal.value + newVal - svStartValue.value;
+            runOnJS(handleBumpFeedback)();
         })
         .onEnd(() => {
+            // onFinalize can run after onEnd, so guard the JS/Redux commit.
+            if (!svDidFlush.value) {
+                svDidFlush.value = true;
+                if (svPendingValue.value !== svStartValue.value) {
+                    runOnJS(flushPendingChange)(svPendingValue.value);
+                }
+            }
             svIsDragging.value = false;
             svAccDeg.value = 0;
             runOnJS(stopLongPress)();
             runOnJS(handleDeactivate)();
         })
         .onFinalize(() => {
+            // onEnd can run before onFinalize, so guard the JS/Redux commit.
+            if (!svDidFlush.value) {
+                svDidFlush.value = true;
+                if (svPendingValue.value !== svStartValue.value) {
+                    runOnJS(flushPendingChange)(svPendingValue.value);
+                }
+            }
             svIsDragging.value = false;
             svAccDeg.value = 0;
             runOnJS(stopLongPress)();
@@ -424,6 +460,8 @@ const DialControl: React.FC<Props> = ({
                                     animatedProps={centerValueAnimProps}
                                     defaultValue={fmtSigned(svValue.value)}
                                     style={[styles.centerNumber, { color: ink, fontSize: D * 0.20, padding: 0, backgroundColor: 'transparent' }]}
+                                    adjustsFontSizeToFit
+                                    minimumFontScale={0.65}
                                     editable={false}
                                     caretHidden={true}
                                     underlineColorAndroid="transparent"

--- a/src/components/Interactions/Dial/DialControl.tsx
+++ b/src/components/Interactions/Dial/DialControl.tsx
@@ -20,8 +20,6 @@ import Svg, { Circle, Line, Path } from 'react-native-svg';
 // Extend TextInputProps to include Reanimated's animated text content prop
 type AnimatedTextInputProps = TextInputProps & {
     text?: string;
-    adjustsFontSizeToFit?: boolean;
-    minimumFontScale?: number;
 };
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput as React.ComponentType<AnimatedTextInputProps>);
 
@@ -34,6 +32,15 @@ const AnimatedPath = Animated.createAnimatedComponent(Path);
 const STEP_DEG = 30;
 const ACCENT = '#3a86ff';
 const MOVE_THRESHOLD_SQ = 100;
+const CENTER_VALUE_BASE_FONT_RATIO = 0.20;
+const CENTER_VALUE_MIN_SCALE = 0.62;
+const CENTER_VALUE_TARGET_CHARS = 4;
+
+export function getCenterValueFontScale(value: number): number {
+    'worklet';
+    const textLength = value > 0 ? String(value).length + 1 : String(value).length;
+    return Math.max(CENTER_VALUE_MIN_SCALE, Math.min(1, CENTER_VALUE_TARGET_CHARS / textLength));
+}
 
 // TODO: see RowsBoard.tsx — consolidate inkFor/inkA into shared colorUtils module
 function inkA(ink: string, a: number): string {
@@ -98,6 +105,9 @@ const DialControl: React.FC<Props> = ({
     const numScale = useSharedValue(1);
     const numScaleStyle = useAnimatedStyle(() => ({
         transform: [{ scale: numScale.value }],
+    }));
+    const centerNumberFitStyle = useAnimatedStyle(() => ({
+        fontSize: D * CENTER_VALUE_BASE_FONT_RATIO * getCenterValueFontScale(svValue.value),
     }));
 
     const arrowBob = useSharedValue(0);
@@ -455,13 +465,11 @@ const DialControl: React.FC<Props> = ({
                     {/* Centre value */}
                     <View style={StyleSheet.absoluteFill} pointerEvents="none">
                         <View style={styles.centerValue}>
-                            <Animated.View style={[numScaleStyle, { width: D * 0.54 }]}>
+                            <Animated.View style={[numScaleStyle, { width: D * 0.62 }]}>
                                 <AnimatedTextInput
                                     animatedProps={centerValueAnimProps}
                                     defaultValue={fmtSigned(svValue.value)}
-                                    style={[styles.centerNumber, { color: ink, fontSize: D * 0.20, padding: 0, backgroundColor: 'transparent' }]}
-                                    adjustsFontSizeToFit
-                                    minimumFontScale={0.65}
+                                    style={[styles.centerNumber, centerNumberFitStyle, { color: ink, padding: 0, backgroundColor: 'transparent' }]}
                                     editable={false}
                                     caretHidden={true}
                                     underlineColorAndroid="transparent"


### PR DESCRIPTION
## Summary
- keep dial score and new total updates on shared values during fast spins
- flush the final dial value to Redux once per gesture end/finalize
- skip unchanged round score writes in the players reducer

## Testing
- Not run: local Jest/TS/ESLint binaries were unavailable in this worktree, and registry access for npx was declined.