### PR TITLE
fix: dispatch setRollingGameCounter instead of calling action creator directly

### DIFF
--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -41,7 +41,7 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
 
         // Update rollingGameCounter if it is undefined or less than the current gameIds length
         if (rollingGameCounter === undefined || rollingGameCounter < gameIds.length) {
-            setRollingGameCounter(gameIds.length);
+            dispatch(setRollingGameCounter(gameIds.length));
         }
 
         logEvent('game_list', {


### PR DESCRIPTION
## Summary

- `setRollingGameCounter(gameIds.length)` was being called as a plain function in `ListScreen`'s `useEffect`, discarding the returned action object without dispatching it
- As a result `rollingGameCounter` in Redux state never updated
- One-character fix: wrap the call in `dispatch()`

## Test plan

- [ ] Launch the app, create a few games, verify `rollingGameCounter` increments (observable via dev menu or Redux DevTools)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6ZfPpfLZaAcapYmtQjfXm)_