### PR TITLE
fix: replace dead-condition reduce in TotalScoreCell with memoized selector

### DIFF
--- a/redux/PlayersSlice.test.ts
+++ b/redux/PlayersSlice.test.ts
@@ -4,7 +4,9 @@ import playersReducer, {
     playerAdd,
     playerRoundScoreIncrement,
     playerRoundScoreSet,
+    selectPlayerGrandTotalScore,
 } from '../redux/PlayersSlice';
+import { RootState } from '../redux/store';
 
 describe('players reducer', () => {
     const initialState = {
@@ -104,5 +106,50 @@ describe('players reducer', () => {
         }));
         const next = playersReducer(actual, playerRoundScoreSet('1', 1, 20));
         expect(next).toBe(actual);
+    });
+});
+
+describe('selectPlayerGrandTotalScore', () => {
+    const stateWithScores = (scores: number[]): RootState => {
+        const state: Partial<RootState> = {
+            players: {
+                ids: ['1'],
+                entities: {
+                    '1': { id: '1', playerName: 'Test', scores },
+                },
+            },
+        };
+        return state as RootState;
+    };
+
+    it('should sum scores across all rounds', () => {
+        expect(selectPlayerGrandTotalScore(stateWithScores([10, 20, 30]), '1')).toEqual(60);
+    });
+
+    it('should sum negative and positive scores', () => {
+        expect(selectPlayerGrandTotalScore(stateWithScores([10, -25, 5]), '1')).toEqual(-10);
+    });
+
+    it('should return 0 for a player with no scores', () => {
+        expect(selectPlayerGrandTotalScore(stateWithScores([]), '1')).toEqual(0);
+    });
+
+    it('should return 0 for an unknown player id', () => {
+        expect(selectPlayerGrandTotalScore(stateWithScores([10, 20]), 'missing')).toEqual(0);
+    });
+
+    it('should treat null round entries as 0', () => {
+        const scores = [10, null, 20] as unknown as number[];
+        expect(selectPlayerGrandTotalScore(stateWithScores(scores), '1')).toEqual(30);
+    });
+
+    it('should reflect score updates applied through the reducer', () => {
+        let players = playersReducer(undefined, playerAdd({
+            id: '1',
+            playerName: 'Test',
+            scores: [10, 20, 30],
+        }));
+        players = playersReducer(players, playerRoundScoreIncrement('1', 1, 5));
+        expect(selectPlayerGrandTotalScore({ players } as RootState, '1')).toEqual(65);
     });
 });

--- a/redux/PlayersSlice.ts
+++ b/redux/PlayersSlice.ts
@@ -114,6 +114,11 @@ export const selectPlayerScoreByRound = createSelector(
     (entities, playerId, round) => entities[playerId]?.scores[round] || 0
 );
 
+export const selectPlayerTotalScore = createSelector(
+    [(state: RootState, playerId: string) => state.players.entities[playerId]],
+    (player) => player?.scores?.reduce((sum, s) => sum + (s || 0), 0) ?? 0
+);
+
 export const selectPlayerRoundStats = createSelector(
     [
         (state: RootState, playerId: string) => state.players.entities[playerId],

--- a/redux/PlayersSlice.ts
+++ b/redux/PlayersSlice.ts
@@ -114,7 +114,7 @@ export const selectPlayerScoreByRound = createSelector(
     (entities, playerId, round) => entities[playerId]?.scores[round] || 0
 );
 
-export const selectPlayerTotalScore = createSelector(
+export const selectPlayerGrandTotalScore = createSelector(
     [(state: RootState, playerId: string) => state.players.entities[playerId]],
     (player) => player?.scores?.reduce((sum, s) => sum + (s || 0), 0) ?? 0
 );

--- a/src/components/ScoreLog/TotalScoreCell.tsx
+++ b/src/components/ScoreLog/TotalScoreCell.tsx
@@ -3,7 +3,7 @@ import React, { memo } from 'react';
 import { Text, StyleSheet } from 'react-native';
 
 import { useAppSelector } from '../../../redux/hooks';
-import { selectPlayerTotalScore } from '../../../redux/PlayersSlice';
+import { selectPlayerGrandTotalScore } from '../../../redux/PlayersSlice';
 import { useTheme } from '../../theme';
 
 export type Props = {
@@ -11,7 +11,7 @@ export type Props = {
 }
 const TotalScoreCell: React.FunctionComponent<Props> = ({ playerId }) => {
     const theme = useTheme();
-    const scoreTotal = useAppSelector(state => selectPlayerTotalScore(state, playerId));
+    const scoreTotal = useAppSelector(state => selectPlayerGrandTotalScore(state, playerId));
     return (
         <Text key={playerId} style={[styles.scoreEntry, { color: theme.text }]}>
             {scoreTotal}

--- a/src/components/ScoreLog/TotalScoreCell.tsx
+++ b/src/components/ScoreLog/TotalScoreCell.tsx
@@ -1,9 +1,9 @@
 import React, { memo } from 'react';
 
-import { Text , StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 
 import { useAppSelector } from '../../../redux/hooks';
-import { selectPlayerById } from '../../../redux/PlayersSlice';
+import { selectPlayerTotalScore } from '../../../redux/PlayersSlice';
 import { useTheme } from '../../theme';
 
 export type Props = {
@@ -11,16 +11,10 @@ export type Props = {
 }
 const TotalScoreCell: React.FunctionComponent<Props> = ({ playerId }) => {
     const theme = useTheme();
-    const scores: number[] = useAppSelector(state => (selectPlayerById(state, playerId) || { scores: [] }).scores);
-    const totalScore = scores.reduce((sum, current, round) => {
-        if (round > round) {
-            return sum;
-        }
-        return (sum || 0) + (current || 0);
-    });
+    const scoreTotal = useAppSelector(state => selectPlayerTotalScore(state, playerId));
     return (
         <Text key={playerId} style={[styles.scoreEntry, { color: theme.text }]}>
-            {totalScore}
+            {scoreTotal}
         </Text>
     );
 };


### PR DESCRIPTION
## Summary

- `TotalScoreCell` had a `reduce` with an unreachable branch (`round > round` is always `false`), making the intent unclear
- The component also fetched the full `scores` array into local state and computed the total itself on every render
- Add `selectPlayerTotalScore` to `PlayersSlice` (memoized via `createSelector`) and use it directly in the component, removing the inline reduce entirely

## Test plan

- [ ] Open the Score Log view for a game with multiple rounds; verify totals match what's shown in the player tile
- [ ] Verify totals still update correctly as scores change

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6ZfPpfLZaAcapYmtQjfXm)_