### PR TITLE
refactor: consolidate repeated selectGameById calls and fix hooks-before-returns

### DIFF
--- a/src/components/GameListItem.test.tsx
+++ b/src/components/GameListItem.test.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { configureStore } from '@reduxjs/toolkit';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import { Provider } from 'react-redux';
+
+import gamesReducer, { gameDelete } from '../../redux/GamesSlice';
+import playersReducer from '../../redux/PlayersSlice';
+import settingsReducer from '../../redux/SettingsSlice';
+
+import GameListItem from './GameListItem';
+
+jest.mock('../Analytics', () => ({
+    logEvent: jest.fn(),
+}));
+
+jest.mock('react-native-reanimated', () => {
+    const View = jest.requireActual('react-native').View;
+
+    return {
+        __esModule: true,
+        default: {
+            View: View,
+        },
+        FadeInUp: {
+            duration: jest.fn(() => ({ delay: jest.fn() })),
+        },
+    };
+});
+
+// Mock react-native-elements ListItem and Icon
+jest.mock('react-native-elements', () => {
+    const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+
+    const ListItem = ({ children, onPress, testID }: {
+        children: React.ReactNode;
+        onPress?: () => void;
+        testID?: string;
+    }) => (
+        <TouchableOpacity testID={testID} onPress={onPress}>{children}</TouchableOpacity>
+    );
+    ListItem.Content = ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
+    ListItem.Title = ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>;
+    ListItem.Subtitle = ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>;
+    ListItem.Chevron = () => <View testID="chevron" />;
+
+    return {
+        ListItem,
+        Icon: ({ name }: { name: string }) => <View testID={`icon-${name}`} />,
+    };
+});
+
+// Capture ContextMenu props so tests can trigger menu actions (iOS popup menu)
+const mockContextMenuProps: {
+    current: {
+        onPress?: (event: { nativeEvent: { index: number } }) => void;
+        onPreviewPress?: () => void;
+        title?: string;
+    } | null;
+} = { current: null };
+
+jest.mock('react-native-context-menu-view', () => {
+    const { View } = jest.requireActual('react-native');
+
+    return {
+        __esModule: true,
+        default: (props: {
+            children: React.ReactNode;
+            onPress?: (event: { nativeEvent: { index: number } }) => void;
+            onPreviewPress?: () => void;
+            title?: string;
+        }) => {
+            mockContextMenuProps.current = props;
+            return <View testID="context-menu">{props.children}</View>;
+        },
+    };
+});
+
+jest.spyOn(Alert, 'alert');
+
+const createMockStore = (initialState: Parameters<typeof configureStore>[0]['preloadedState']) => {
+    return configureStore({
+        reducer: {
+            settings: settingsReducer,
+            games: gamesReducer,
+            players: playersReducer,
+        },
+        preloadedState: initialState,
+    });
+};
+
+const mockNavigation = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+} as unknown as NativeStackNavigationProp<ParamListBase, string, undefined>;
+
+describe('GameListItem', () => {
+    const mockGame = {
+        id: 'game-1',
+        title: 'Test Game',
+        dateCreated: Date.now(),
+        roundCurrent: 1,
+        roundTotal: 3,
+        playerIds: ['player-1', 'player-2'],
+        locked: false,
+    };
+
+    const mockPlayers = {
+        'player-1': { id: 'player-1', playerName: 'Player 1', scores: [10] },
+        'player-2': { id: 'player-2', playerName: 'Player 2', scores: [5] },
+    };
+
+    const populatedState = {
+        settings: {},
+        games: {
+            entities: { 'game-1': mockGame },
+            ids: ['game-1'],
+        },
+        players: {
+            entities: mockPlayers,
+            ids: ['player-1', 'player-2'],
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockContextMenuProps.current = null;
+    });
+
+    it('should render game title, players, and badges for a valid game', () => {
+        const store = createMockStore(populatedState);
+
+        const { getByText, getByTestId } = render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+            </Provider>
+        );
+
+        expect(getByTestId('game-list-item')).toBeTruthy();
+        expect(getByText('Test Game')).toBeTruthy();
+        expect(getByText('Player 1, ')).toBeTruthy();
+        expect(getByText('Player 2')).toBeTruthy();
+    });
+
+    it('should show lock icon when game is locked', () => {
+        const store = createMockStore({
+            ...populatedState,
+            games: {
+                entities: { 'game-1': { ...mockGame, locked: true } },
+                ids: ['game-1'],
+            },
+        });
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+            </Provider>
+        );
+
+        expect(getByTestId('icon-lock-closed-outline')).toBeTruthy();
+    });
+
+    it('should render null when the game is not in the store', () => {
+        const store = createMockStore(populatedState);
+
+        const { toJSON } = render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="missing-game" index={0} />
+            </Provider>
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render null without crashing when the game is deleted after mount', () => {
+        const store = createMockStore(populatedState);
+
+        const { getByText, toJSON } = render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+            </Provider>
+        );
+
+        expect(getByText('Test Game')).toBeTruthy();
+
+        act(() => {
+            store.dispatch(gameDelete('game-1'));
+        });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should set current game and navigate to Game when pressed', () => {
+        const store = createMockStore(populatedState);
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+            </Provider>
+        );
+
+        fireEvent.press(getByTestId('game-list-item'));
+
+        expect(mockNavigation.navigate).toHaveBeenCalledWith('Game');
+        expect(store.getState().settings.currentGameId).toBe('game-1');
+    });
+
+    it('should show delete confirmation when delete is chosen from the popup menu', () => {
+        const store = createMockStore(populatedState);
+
+        render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+            </Provider>
+        );
+
+        expect(mockContextMenuProps.current?.title).toBe('Test Game');
+
+        act(() => {
+            mockContextMenuProps.current?.onPress?.({ nativeEvent: { index: 3 } });
+        });
+
+        expect(Alert.alert).toHaveBeenCalledWith(
+            'Delete Game',
+            'Are you sure you want to delete Test Game?',
+            expect.arrayContaining([
+                expect.objectContaining({ text: 'Cancel' }),
+                expect.objectContaining({ text: 'OK' }),
+            ]),
+            { cancelable: false },
+        );
+    });
+});

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -41,15 +41,15 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
     const dispatch = useAppDispatch();
     const game = useAppSelector(state => selectGameById(state, gameId));
 
+    const setCurrentGameCallback = useCallback(() => {
+        dispatch(setCurrentGameId(gameId));
+    }, [gameId]);
+
     if (gameId == null) { return null; }
     if (!game) { return null; }
 
     const { roundTotal: roundCount, playerIds, title: gameTitle, locked, winnerIds, dateCreated } = game;
     if (roundCount == null || playerIds == null) { return null; }
-
-    const setCurrentGameCallback = useCallback(() => {
-        dispatch(setCurrentGameId(gameId));
-    }, [gameId]);
 
     /**
      * Choose Game and navigate to GameScreen

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -39,15 +39,12 @@ export type Props = {
 const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, index }) => {
     const theme = useTheme();
     const dispatch = useAppDispatch();
+    const game = useAppSelector(state => selectGameById(state, gameId));
 
     if (gameId == null) { return null; }
+    if (!game) { return null; }
 
-    const roundCount = useAppSelector(state => selectGameById(state, gameId)?.roundTotal);
-    const playerIds = useAppSelector(state => selectGameById(state, gameId)?.playerIds);
-    const gameTitle = useAppSelector(state => selectGameById(state, gameId)?.title);
-    const locked = useAppSelector(state => selectGameById(state, gameId)?.locked);
-    const winnerIds = useAppSelector(state => selectGameById(state, gameId)?.winnerIds);
-    const dateCreated = useAppSelector(state => selectGameById(state, gameId)?.dateCreated);
+    const { roundTotal: roundCount, playerIds, title: gameTitle, locked, winnerIds, dateCreated } = game;
     if (roundCount == null || playerIds == null) { return null; }
 
     const setCurrentGameCallback = useCallback(() => {

--- a/src/components/PopupMenu/AbstractPopupMenu.tsx
+++ b/src/components/PopupMenu/AbstractPopupMenu.tsx
@@ -22,11 +22,12 @@ interface Props {
 
 const AbstractPopupMenu: React.FC<Props> = (props) => {
     const dispatch = useAppDispatch();
+    const game = useAppSelector(state => selectGameById(state, props.gameId));
 
     if (props.gameId == null) { return null; }
-    const gameTitle = useAppSelector(state => selectGameById(state, props.gameId)?.title);
-    const roundCount = useAppSelector(state => selectGameById(state, props.gameId)?.roundTotal);
-    const playerIds = useAppSelector(state => selectGameById(state, props.gameId)?.playerIds);
+    if (!game) { return null; }
+
+    const { roundTotal: roundCount, playerIds, title: gameTitle } = game;
     if (roundCount == null || playerIds == null) { return null; }
 
     /**

--- a/src/components/Sheets/GameSheet.tsx
+++ b/src/components/Sheets/GameSheet.tsx
@@ -30,9 +30,10 @@ const GameSheet: React.FunctionComponent = () => {
     const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
     const { height: containerHeight } = useWindowDimensions();
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
-    const gameTitle = useAppSelector(state => selectGameById(state, currentGameId || '')?.title);
-    const gameLocked = useAppSelector(state => selectGameById(state, currentGameId || '')?.locked);
-    const playerIds = useAppSelector(state => selectGameById(state, currentGameId || '')?.playerIds);
+    const game = useAppSelector(state => selectGameById(state, currentGameId || ''));
+    const gameTitle = game?.title;
+    const gameLocked = game?.locked;
+    const playerIds = game?.playerIds;
     const chooseWinnersSheetRef = useChooseWinnersSheetContext();
 
     if (currentGameId == undefined) return null;


### PR DESCRIPTION
## Summary

- `GameListItem`, `AbstractPopupMenu`, and `GameSheet` each called `selectGameById` in a separate `useAppSelector` for every field they needed (up to 6 calls hitting the same entity lookup). Collapsed to a single call per component and destructured the needed fields.
- `GameListItem` and `AbstractPopupMenu` had an early `return null` guard *before* their `useAppSelector` hook calls, violating React's rules of hooks (hooks must not be called conditionally). The guard is moved to after all hooks.

## Test plan

- [ ] Open the game list; verify games render correctly with title, player names, round count, and date
- [ ] Tap the popup menu on a game; verify all menu actions (edit, rematch, share, delete) work
- [ ] Open the game sheet from within a game; verify title, lock state, and score log render correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6ZfPpfLZaAcapYmtQjfXm)_