### PR TITLE
Add test coverage for core score calculation pipeline

### DIFF
--- a/redux/PlayersSlice.test.ts
+++ b/redux/PlayersSlice.test.ts
@@ -4,9 +4,24 @@ import playersReducer, {
     playerAdd,
     playerRoundScoreIncrement,
     playerRoundScoreSet,
+    selectAllPlayers,
     selectPlayerGrandTotalScore,
+    selectPlayerRoundStats,
+    selectPlayerScoreByRound,
 } from '../redux/PlayersSlice';
 import { RootState } from '../redux/store';
+
+const stateWithScores = (scores: number[]): RootState => {
+    const state: Partial<RootState> = {
+        players: {
+            ids: ['1'],
+            entities: {
+                '1': { id: '1', playerName: 'Test', scores },
+            },
+        },
+    };
+    return state as RootState;
+};
 
 describe('players reducer', () => {
     const initialState = {
@@ -107,21 +122,199 @@ describe('players reducer', () => {
         const next = playersReducer(actual, playerRoundScoreSet('1', 1, 20));
         expect(next).toBe(actual);
     });
+
+    it('should coerce a null round entry to 0 before incrementing', () => {
+        let actual = playersReducer(initialState, playerAdd({
+            id: '1',
+            playerName: 'Test',
+            scores: [10, null] as unknown as number[],
+        }));
+        actual = playersReducer(actual, playerRoundScoreIncrement('1', 1, 5));
+        if (actual.entities['1'] === undefined) {
+            throw ('Player not found');
+        }
+        expect(actual.entities['1'].scores).toEqual([10, 5]);
+    });
+
+    it('should not change player scores when incrementing an unknown player', () => {
+        const actual = playersReducer(initialState, playerAdd({
+            id: '1',
+            playerName: 'Test',
+            scores: [10, 20, 30],
+        }));
+        const next = playersReducer(actual, playerRoundScoreIncrement('missing', 0, 5));
+        expect(next.ids).toEqual(['1']);
+        expect(next.entities['missing']).toBeUndefined();
+        expect(next.entities['1']?.scores).toEqual([10, 20, 30]);
+    });
+
+    it('should not change player scores when setting a score for an unknown player', () => {
+        const actual = playersReducer(initialState, playerAdd({
+            id: '1',
+            playerName: 'Test',
+            scores: [10, 20, 30],
+        }));
+        const next = playersReducer(actual, playerRoundScoreSet('missing', 0, 5));
+        expect(next.ids).toEqual(['1']);
+        expect(next.entities['missing']).toBeUndefined();
+        expect(next.entities['1']?.scores).toEqual([10, 20, 30]);
+    });
+
+    it('should handle playerRoundScoreSet beyond the current scores length', () => {
+        let actual = playersReducer(initialState, playerAdd({
+            id: '1',
+            playerName: 'Test',
+            scores: [10],
+        }));
+        actual = playersReducer(actual, playerRoundScoreSet('1', 2, 7));
+        if (actual.entities['1'] === undefined) {
+            throw ('Player not found');
+        }
+        expect(actual.entities['1'].scores[2]).toEqual(7);
+        expect(actual.entities['1'].scores[0]).toEqual(10);
+        expect(actual.entities['1'].scores.length).toEqual(3);
+    });
+});
+
+describe('player sort order', () => {
+    it('should order players by descending grand total on add', () => {
+        let players = playersReducer(undefined, playerAdd({
+            id: 'low',
+            playerName: 'Low',
+            scores: [5, 5],
+        }));
+        players = playersReducer(players, playerAdd({
+            id: 'high',
+            playerName: 'High',
+            scores: [30, 30],
+        }));
+        players = playersReducer(players, playerAdd({
+            id: 'spiky',
+            playerName: 'Spiky',
+            scores: [50, -10],
+        }));
+        const ordered = selectAllPlayers({ players }).map((p) => p.id);
+        expect(ordered).toEqual(['high', 'spiky', 'low']);
+    });
+
+    it('does not re-sort when an increment changes the leader (sort applies on add/upsert only)', () => {
+        let players = playersReducer(undefined, playerAdd({
+            id: 'a',
+            playerName: 'A',
+            scores: [10],
+        }));
+        players = playersReducer(players, playerAdd({
+            id: 'b',
+            playerName: 'B',
+            scores: [5],
+        }));
+        players = playersReducer(players, playerRoundScoreIncrement('b', 0, 100));
+        const ordered = selectAllPlayers({ players }).map((p) => p.id);
+        expect(ordered).toEqual(['a', 'b']);
+    });
+
+    it('should keep both players when grand totals are tied', () => {
+        let players = playersReducer(undefined, playerAdd({
+            id: 'a',
+            playerName: 'A',
+            scores: [10, 20],
+        }));
+        players = playersReducer(players, playerAdd({
+            id: 'b',
+            playerName: 'B',
+            scores: [30],
+        }));
+        const ordered = selectAllPlayers({ players }).map((p) => p.id);
+        expect(ordered).toHaveLength(2);
+        expect(ordered).toEqual(expect.arrayContaining(['a', 'b']));
+    });
+});
+
+describe('selectPlayerScoreByRound', () => {
+    it('should return the score for the requested round', () => {
+        expect(selectPlayerScoreByRound(stateWithScores([10, 20, 30]), '1', 1)).toEqual(20);
+    });
+
+    it('should return 0 for a round beyond the scores length', () => {
+        expect(selectPlayerScoreByRound(stateWithScores([10, 20]), '1', 5)).toEqual(0);
+    });
+
+    it('should return 0 for an unknown player id', () => {
+        expect(selectPlayerScoreByRound(stateWithScores([10, 20]), 'missing', 0)).toEqual(0);
+    });
+
+    it('should return 0 for a round with a stored 0', () => {
+        expect(selectPlayerScoreByRound(stateWithScores([10, 0, 30]), '1', 1)).toEqual(0);
+    });
+});
+
+describe('selectPlayerRoundStats', () => {
+    it('should break down scores for a mid-game round', () => {
+        expect(selectPlayerRoundStats(stateWithScores([10, 20, 30]), '1', 1)).toEqual({
+            currentRoundScore: 20,
+            previousTotal: 10,
+            currentRoundTotalScore: 30,
+            grandTotalScore: 60,
+        });
+    });
+
+    it('should have no previous total on the first round', () => {
+        expect(selectPlayerRoundStats(stateWithScores([10, 20, 30]), '1', 0)).toEqual({
+            currentRoundScore: 10,
+            previousTotal: 0,
+            currentRoundTotalScore: 10,
+            grandTotalScore: 60,
+        });
+    });
+
+    it('should treat a round beyond the scores length as 0 with full previous total', () => {
+        expect(selectPlayerRoundStats(stateWithScores([10, 20]), '1', 5)).toEqual({
+            currentRoundScore: 0,
+            previousTotal: 30,
+            currentRoundTotalScore: 30,
+            grandTotalScore: 30,
+        });
+    });
+
+    it('should handle negative scores in the running totals', () => {
+        expect(selectPlayerRoundStats(stateWithScores([10, -25, 5]), '1', 1)).toEqual({
+            currentRoundScore: -25,
+            previousTotal: 10,
+            currentRoundTotalScore: -15,
+            grandTotalScore: -10,
+        });
+    });
+
+    it('should treat null round entries as 0', () => {
+        const scores = [10, null, 20] as unknown as number[];
+        expect(selectPlayerRoundStats(stateWithScores(scores), '1', 2)).toEqual({
+            currentRoundScore: 20,
+            previousTotal: 10,
+            currentRoundTotalScore: 30,
+            grandTotalScore: 30,
+        });
+    });
+
+    it('should return all zeros for an unknown player id', () => {
+        expect(selectPlayerRoundStats(stateWithScores([10, 20]), 'missing', 0)).toEqual({
+            currentRoundScore: 0,
+            previousTotal: 0,
+            currentRoundTotalScore: 0,
+            grandTotalScore: 0,
+        });
+    });
+
+    it('should return all zeros for a player with no scores', () => {
+        expect(selectPlayerRoundStats(stateWithScores([]), '1', 0)).toEqual({
+            currentRoundScore: 0,
+            previousTotal: 0,
+            currentRoundTotalScore: 0,
+            grandTotalScore: 0,
+        });
+    });
 });
 
 describe('selectPlayerGrandTotalScore', () => {
-    const stateWithScores = (scores: number[]): RootState => {
-        const state: Partial<RootState> = {
-            players: {
-                ids: ['1'],
-                entities: {
-                    '1': { id: '1', playerName: 'Test', scores },
-                },
-            },
-        };
-        return state as RootState;
-    };
-
     it('should sum scores across all rounds', () => {
         expect(selectPlayerGrandTotalScore(stateWithScores([10, 20, 30]), '1')).toEqual(60);
     });

--- a/src/components/Interactions/HalfTap/HalfTileTouchSurface.test.tsx
+++ b/src/components/Interactions/HalfTap/HalfTileTouchSurface.test.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render } from '@testing-library/react-native';
+import { TouchableHighlight } from 'react-native';
+import { Provider } from 'react-redux';
+
+import { playerRoundScoreIncrement } from '../../../../redux/PlayersSlice';
+
+import { HalfTileTouchSurface } from './HalfTileTouchSurface';
+
+jest.mock('../../../Analytics', () => ({ logEvent: function () { } }));
+jest.mock('expo-haptics', () => ({
+  impactAsync: function () { },
+  ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
+}));
+jest.mock('../../PlayerTiles/AdditionTile/ScoreParticle', () => ({
+  ScoreParticle: function () { return null; },
+}));
+
+let mockMenuOpen = false;
+jest.mock('../../MenuOpenContext', () => ({
+  useMenuOpen: function () { return { menuOpen: mockMenuOpen, setMenuOpen: function () { } }; },
+}));
+
+const stub = function (s: any = {}) { return s; };
+
+beforeEach(() => {
+  mockMenuOpen = false;
+});
+
+type RenderOptions = {
+  scoreType?: 'increment' | 'decrement';
+  roundCurrent?: number;
+  locked?: boolean;
+};
+
+const renderSurface = ({ scoreType = 'increment', roundCurrent = 0, locked = false }: RenderOptions = {}) => {
+  const store = configureStore({
+    reducer: { settings: stub, games: stub, players: stub },
+    preloadedState: {
+      settings: { addendOne: 3, addendTwo: 10, currentGameId: 'game-1', multiplier: '1', onboarded: null, interactionType: null, showPointParticles: true, _persist: { version: 0, rehydrated: true } },
+      games: { ids: ['game-1'], entities: { 'game-1': { id: 'game-1', title: 'Test', dateCreated: Date.now(), roundCurrent, roundTotal: roundCurrent + 1, locked, playerIds: ['player-1'] } }, _persist: { version: 0, rehydrated: true } },
+      players: { ids: ['player-1'], entities: { 'player-1': { id: 'player-1', playerName: 'Test', scores: [0] } }, _persist: { version: 0, rehydrated: true } },
+    },
+  });
+  const dispatch = jest.spyOn(store, 'dispatch');
+  const utils = render(
+    <Provider store={store}>
+      <HalfTileTouchSurface playerIndex={0} playerId="player-1" fontColor="white" scoreType={scoreType} />
+    </Provider>
+  );
+  const surface = utils.UNSAFE_getByType(TouchableHighlight);
+  return { dispatch, surface };
+};
+
+describe('HalfTileTouchSurface', () => {
+  it('tap on the increment surface dispatches +addendOne for the current round', () => {
+    const { dispatch, surface } = renderSurface({ scoreType: 'increment' });
+    fireEvent.press(surface);
+    expect(dispatch).toHaveBeenCalledWith(
+      playerRoundScoreIncrement('player-1', 0, 3)
+    );
+  });
+
+  it('tap on the decrement surface dispatches -addendOne', () => {
+    const { dispatch, surface } = renderSurface({ scoreType: 'decrement' });
+    fireEvent.press(surface);
+    expect(dispatch).toHaveBeenCalledWith(
+      playerRoundScoreIncrement('player-1', 0, -3)
+    );
+  });
+
+  it('long press dispatches +addendTwo', () => {
+    const { dispatch, surface } = renderSurface({ scoreType: 'increment' });
+    fireEvent(surface, 'longPress');
+    expect(dispatch).toHaveBeenCalledWith(
+      playerRoundScoreIncrement('player-1', 0, 10)
+    );
+  });
+
+  it('long press on the decrement surface dispatches -addendTwo', () => {
+    const { dispatch, surface } = renderSurface({ scoreType: 'decrement' });
+    fireEvent(surface, 'longPress');
+    expect(dispatch).toHaveBeenCalledWith(
+      playerRoundScoreIncrement('player-1', 0, -10)
+    );
+  });
+
+  it('targets the game\'s current round', () => {
+    const { dispatch, surface } = renderSurface({ roundCurrent: 2 });
+    fireEvent.press(surface);
+    expect(dispatch).toHaveBeenCalledWith(
+      playerRoundScoreIncrement('player-1', 2, 3)
+    );
+  });
+
+  it('does not dispatch when the game is locked', () => {
+    const { dispatch, surface } = renderSurface({ locked: true });
+    fireEvent.press(surface);
+    fireEvent(surface, 'longPress');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch while the menu is open', () => {
+    mockMenuOpen = true;
+    const { dispatch, surface } = renderSurface();
+    fireEvent.press(surface);
+    fireEvent(surface, 'longPress');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ScoreLog/RoundScoreCell.test.tsx
+++ b/src/components/ScoreLog/RoundScoreCell.test.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+
+import RoundScoreCell from './RoundScoreCell';
+
+const stub = function (s: any = {}) { return s; };
+
+const renderCell = (scores: number[], round: number) => {
+    const store = configureStore({
+        reducer: { settings: stub, games: stub, players: stub },
+        preloadedState: {
+            settings: { colorScheme: 'system', _persist: { version: 0, rehydrated: true } },
+            games: { ids: [], entities: {}, _persist: { version: 0, rehydrated: true } },
+            players: { ids: ['player-1'], entities: { 'player-1': { id: 'player-1', playerName: 'Test', scores } }, _persist: { version: 0, rehydrated: true } },
+        },
+    });
+    return render(
+        <Provider store={store}>
+            <RoundScoreCell playerId="player-1" round={round} playerIndex={0} />
+        </Provider>
+    );
+};
+
+describe('RoundScoreCell', () => {
+    it('renders the score for the requested round', () => {
+        const { getByText } = renderCell([10, 20, 30], 1);
+        expect(getByText('20')).toBeTruthy();
+    });
+
+    it('renders a negative round score', () => {
+        const { getByText } = renderCell([10, -5], 1);
+        expect(getByText('-5')).toBeTruthy();
+    });
+
+    it('renders 0 for a round beyond the scores length', () => {
+        const { getByText } = renderCell([10], 4);
+        expect(getByText('0')).toBeTruthy();
+    });
+});

--- a/src/components/ScoreLog/TotalScoreCell.test.tsx
+++ b/src/components/ScoreLog/TotalScoreCell.test.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+
+import TotalScoreCell from './TotalScoreCell';
+
+const stub = function (s: any = {}) { return s; };
+
+const renderCell = (scores: number[]) => {
+    const store = configureStore({
+        reducer: { settings: stub, games: stub, players: stub },
+        preloadedState: {
+            settings: { colorScheme: 'system', _persist: { version: 0, rehydrated: true } },
+            games: { ids: [], entities: {}, _persist: { version: 0, rehydrated: true } },
+            players: { ids: ['player-1'], entities: { 'player-1': { id: 'player-1', playerName: 'Test', scores } }, _persist: { version: 0, rehydrated: true } },
+        },
+    });
+    return render(
+        <Provider store={store}>
+            <TotalScoreCell playerId="player-1" />
+        </Provider>
+    );
+};
+
+describe('TotalScoreCell', () => {
+    it('renders the grand total across all rounds', () => {
+        const { getByText } = renderCell([10, 20, 30]);
+        expect(getByText('60')).toBeTruthy();
+    });
+
+    it('renders a negative grand total', () => {
+        const { getByText } = renderCell([10, -25, 5]);
+        expect(getByText('-10')).toBeTruthy();
+    });
+
+    it('renders 0 for a player with no scores', () => {
+        const { getByText } = renderCell([]);
+        expect(getByText('0')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary

Coverage audit of the score calculation pipeline (gesture → reducer → selector → display cell) found several core paths with no tests. This PR closes those gaps — tests only, no production code changes.

### Redux math (`redux/PlayersSlice.test.ts`, 19 new tests)
- **`selectPlayerRoundStats`** — first direct tests for the most complex score math in the app (current round score / previous total / running total / grand total), covering mid-game rounds, round 0, out-of-range rounds, negative scores, null entries from persisted state, unknown players, and empty score arrays
- **`selectPlayerScoreByRound`** — round lookup with 0 fallbacks (previously untested)
- **Entity adapter sort order** — players ordered by descending grand total on add; plus a test documenting that score increments do **not** re-sort (the comparator only runs on adapter add/upsert — benign today since `SortHelper` and `ChooseWinnersSheet` sort independently)
- **Reducer edge cases** — null score coercion on increment, unknown-player no-ops, `playerRoundScoreSet` beyond the current array length

### Interaction layer (`HalfTileTouchSurface.test.tsx`, new file, 7 tests)
The tap interaction mode had no test file at all (Swipe and Dial both do). Now covered: tap → ±`addendOne`, long-press → ±`addendTwo`, current-round targeting, and the locked-game / menu-open guards.

### Display cells (`TotalScoreCell.test.tsx`, `RoundScoreCell.test.tsx`, new files, 6 tests)
Both cells were mocked out of every existing suite, so selector→display wiring never executed in tests. Now rendered against a real store: grand totals (including negative), per-round scores, and 0 fallbacks.

## Notes from the audit (not changed here)
- `playerRoundScoreIncrement` does `Number(multiplier)` with no NaN guard — a NaN delta would poison the stored score
- The adapter `sortComparer` never returns 0 for ties, so tie ordering is unstable across re-sorts

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full suite: 36 suites, 352 tests passing
- [x] Coverage: `PlayersSlice.ts` 86.5% statements (remaining: crashlytics catch blocks, `restoreAllPlayers`), both display cells 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)