### PR TITLE
Hide game sheet on transition start

### DIFF
--- a/src/Navigation.test.tsx
+++ b/src/Navigation.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { act, render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+
+import gamesReducer from '../redux/GamesSlice';
+import playersReducer from '../redux/PlayersSlice';
+import settingsReducer, { initialState as settingsInitialState } from '../redux/SettingsSlice';
+
+import { Navigation } from './Navigation';
+
+type MockScreenListeners = {
+    blur?: () => void;
+    focus?: () => void;
+    transitionStart?: (event: { data: { closing: boolean } }) => void;
+};
+
+const mockScreenListeners: Record<string, MockScreenListeners | undefined> = {};
+
+jest.mock('@react-navigation/native', () => {
+    const actual = jest.requireActual('@react-navigation/native');
+
+    return {
+        ...actual,
+        NavigationContainer: ({ children }: { children: React.ReactNode }) => {
+            const { View } = jest.requireActual('react-native');
+            return <View>{children}</View>;
+        },
+    };
+});
+
+jest.mock('@react-navigation/native-stack', () => ({
+    createNativeStackNavigator: () => ({
+        Navigator: ({ children }: { children: React.ReactNode }) => {
+            const { View } = jest.requireActual('react-native');
+            return <View>{children}</View>;
+        },
+        Screen: ({ name, listeners }: { name: string; listeners?: MockScreenListeners }) => {
+            mockScreenListeners[name] = listeners;
+            return null;
+        },
+    }),
+}));
+
+jest.mock('./components/Buttons/AppSettingsButton', () => {
+    return function MockAppSettingsButton() {
+        return null;
+    };
+});
+
+jest.mock('./components/Buttons/GameOptionsButton', () => {
+    return function MockGameOptionsButton() {
+        return null;
+    };
+});
+
+jest.mock('./components/Headers/RoundHeaderTitle', () => {
+    return function MockRoundHeaderTitle() {
+        return null;
+    };
+});
+
+jest.mock('./components/Sheets/GameSheet', () => {
+    return function MockGameSheet() {
+        const { View } = jest.requireActual('react-native');
+        return <View testID="game-sheet" />;
+    };
+});
+
+jest.mock('./screens/AppSettingsScreen', () => {
+    return function MockAppSettingsScreen() {
+        return null;
+    };
+});
+
+jest.mock('./screens/DebugLogScreen', () => {
+    return function MockDebugLogScreen() {
+        return null;
+    };
+});
+
+jest.mock('./screens/EditGameScreen', () => {
+    return function MockEditGameScreen() {
+        return null;
+    };
+});
+
+jest.mock('./screens/EditPlayerScreen', () => {
+    return function MockEditPlayerScreen() {
+        return null;
+    };
+});
+
+jest.mock('./screens/GameScreen', () => {
+    return function MockGameScreen() {
+        return null;
+    };
+});
+
+jest.mock('./screens/ListScreen', () => {
+    return function MockListScreen() {
+        return null;
+    };
+});
+
+jest.mock('./screens/ShareScreen', () => {
+    return function MockShareScreen() {
+        return null;
+    };
+});
+
+const createMockStore = (homeFullscreen = false) => configureStore({
+    reducer: {
+        settings: settingsReducer,
+        games: gamesReducer,
+        players: playersReducer,
+    },
+    preloadedState: {
+        settings: {
+            ...settingsInitialState,
+            home_fullscreen: homeFullscreen,
+        },
+    },
+});
+
+const renderNavigation = (homeFullscreen = false) => render(
+    <Provider store={createMockStore(homeFullscreen)}>
+        <Navigation />
+    </Provider>
+);
+
+const getGameListeners = (): Required<MockScreenListeners> => {
+    const listeners = mockScreenListeners.Game;
+
+    if (!listeners?.blur || !listeners.focus || !listeners.transitionStart) {
+        throw new Error('Game screen listeners were not captured.');
+    }
+
+    return listeners as Required<MockScreenListeners>;
+};
+
+describe('Navigation', () => {
+    beforeEach(() => {
+        Object.keys(mockScreenListeners).forEach((key) => {
+            delete mockScreenListeners[key];
+        });
+    });
+
+    it('shows and hides the game sheet from native stack lifecycle events', () => {
+        const { queryByTestId } = renderNavigation();
+        const gameListeners = getGameListeners();
+
+        expect(queryByTestId('game-sheet')).toBeNull();
+
+        act(() => {
+            gameListeners.focus();
+        });
+
+        expect(queryByTestId('game-sheet')).toBeTruthy();
+
+        act(() => {
+            gameListeners.transitionStart({ data: { closing: false } });
+        });
+
+        expect(queryByTestId('game-sheet')).toBeTruthy();
+
+        act(() => {
+            gameListeners.transitionStart({ data: { closing: true } });
+        });
+
+        expect(queryByTestId('game-sheet')).toBeNull();
+
+        act(() => {
+            gameListeners.focus();
+        });
+
+        expect(queryByTestId('game-sheet')).toBeTruthy();
+
+        act(() => {
+            gameListeners.blur();
+        });
+
+        expect(queryByTestId('game-sheet')).toBeNull();
+    });
+
+    it('does not render the game sheet when fullscreen mode is enabled', () => {
+        const { queryByTestId } = renderNavigation(true);
+        const gameListeners = getGameListeners();
+
+        act(() => {
+            gameListeners.focus();
+        });
+
+        expect(queryByTestId('game-sheet')).toBeNull();
+    });
+});

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -51,18 +51,12 @@ export const Navigation = () => {
         : { ...DefaultTheme, colors: { ...DefaultTheme.colors, background: theme.background, card: theme.backgroundSecondary } };
 
     const fullscreen = useAppSelector(state => state.settings.home_fullscreen);
-    const [currentRoute, setCurrentRoute] = useState('List');
+    const [showGameSheet, setShowGameSheet] = useState(false);
 
     return (
         <View style={{ flex: 1 }}>
             <NavigationContainer
                 theme={navTheme}
-                onStateChange={(state) => {
-                    const route = state?.routes[state.index ?? 0];
-                    if (route) {
-                        setCurrentRoute(route.name);
-                    }
-                }}
             >
                 <GestureInfoSheetContextProvider>
                     <MenuOpenContextProvider>
@@ -87,6 +81,15 @@ export const Navigation = () => {
                                 headerBlurEffect: 'systemChromeMaterial',
                                 headerShadowVisible: false,
                                 headerBackButtonDisplayMode: 'minimal',
+                            }}
+                            listeners={{
+                                focus: () => setShowGameSheet(true),
+                                transitionStart: (event) => {
+                                    if (event.data.closing) {
+                                        setShowGameSheet(false);
+                                    }
+                                },
+                                blur: () => setShowGameSheet(false),
                             }}
                         />
                         <Stack.Screen name="EditGame" component={EditGameScreen}
@@ -126,7 +129,7 @@ export const Navigation = () => {
                         </Stack.Navigator>
                     </MenuOpenContextProvider>
                 </GestureInfoSheetContextProvider>
-                {!fullscreen && currentRoute === 'Game' && <GameSheet />}
+                {!fullscreen && showGameSheet && <GameSheet />}
             </NavigationContainer>
         </View>
     );

--- a/src/components/Sheets/GameSheet.tsx
+++ b/src/components/Sheets/GameSheet.tsx
@@ -36,8 +36,6 @@ const GameSheet: React.FunctionComponent = () => {
     const playerIds = game?.playerIds;
     const chooseWinnersSheetRef = useChooseWinnersSheetContext();
 
-    if (currentGameId == undefined) return null;
-
     // ref
     const gameSheetRef = useGameSheetContext();
 
@@ -56,6 +54,8 @@ const GameSheet: React.FunctionComponent = () => {
      * Unlock the game and clear winners
      */
     const unlockGame = () => {
+        if (currentGameId == undefined) return;
+
         dispatch(
             updateGame({
                 id: currentGameId,
@@ -118,6 +118,8 @@ const GameSheet: React.FunctionComponent = () => {
      * Rematch - start new game with same players
      */
     const rematchGameHandler = async () => {
+        if (currentGameId == undefined) return;
+
         Alert.alert(
             'Rematch',
             'This will create a new game with the same players and empty scores.',
@@ -174,6 +176,8 @@ const GameSheet: React.FunctionComponent = () => {
         setSnapPointIndex(index);
         if (index === 0) setShouldRenderContent(false);
     }, []);
+
+    if (currentGameId == undefined) return null;
 
     /**
      * Function to snap to the next point when the handle is pressed


### PR DESCRIPTION
## Summary
- render the game sheet while the Game screen is active
- hide/unmount the sheet as soon as the native-stack Game screen transition starts closing
- keep blur as a fallback for cleanup

## Tests
- npm run lint
- npm test -- --runTestsByPath src/Navigation.test.tsx --watchman=false --coverage=false
- npm test -- --runTestsByPath src/components/Sheets/GameSheet.test.tsx --watchman=false --coverage=false

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/6789bdd4-8034-4719-b8c2-de93a2333997" controls></video> | <video src="https://github.com/user-attachments/assets/bb7aa1ed-367a-4fa9-bd1b-77b27e659639" controls></video> |