### PR TITLE
Bump version to 3.0.2

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -72,7 +72,7 @@ switch (variant) {
 export default {
   name: 'ScorePad with Rounds',
   slug: 'scorepad',
-  version: '3.0.1',
+  version: '3.0.2',
   orientation: 'default',
   icon: icon,
   assetBundlePatterns: ['assets/*'],
@@ -97,7 +97,7 @@ export default {
     package: packageName,
     permissions: [],
     blockedPermissions: ['android.permission.ACTIVITY_RECOGNITION'],
-    versionCode: 87,
+    versionCode: 88,
     googleServicesFile: './google-services.json',
   },
   userInterfaceStyle: 'automatic',


### PR DESCRIPTION
Bumps `app.config.js` version from `3.0.1` → `3.0.2` and Android `versionCode` from `87` → `88`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrLwQWVjY4XfV2pQSoiXof)_