### PR TITLE
Remove unused @react-native-firebase/auth dependency

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -131,7 +131,7 @@ export default {
       {
         ios: {
           useFrameworks: 'static',
-          forceStaticLinking: ['RNFBApp', 'RNFBAnalytics', 'RNFBAuth', 'RNFBCrashlytics'],
+          forceStaticLinking: ['RNFBApp', 'RNFBAnalytics', 'RNFBCrashlytics'],
         },
       },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@react-native-community/masked-view": "^0.1.11",
         "@react-native-firebase/analytics": "^24.0.0",
         "@react-native-firebase/app": "^24.0.0",
-        "@react-native-firebase/auth": "^24.0.0",
         "@react-native-firebase/crashlytics": "^24.0.0",
         "@react-native-menu/menu": "^2.0.0",
         "@react-native-picker/picker": "2.11.4",
@@ -5471,24 +5470,6 @@
         "expo": ">=47.0.0",
         "react": "*",
         "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@react-native-firebase/auth": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-firebase/auth/-/auth-24.0.0.tgz",
-      "integrity": "sha512-LvjVouoTLx2yCkCSy5ZxfDrbZgxMIE5QIFfm2uqWXeP1L1+NVV3MkBMdKruhwIrF0nuLOuzvGdf545rUqRgN6Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "plist": "^3.1.0"
-      },
-      "peerDependencies": {
-        "@react-native-firebase/app": "24.0.0",
-        "expo": ">=47.0.0"
       },
       "peerDependenciesMeta": {
         "expo": {
@@ -24672,14 +24653,6 @@
       "integrity": "sha512-rLWNd8/4FjKYV7PeDR9uiT5vwYWdJ7dJ1yiIIaZ/eL+Y56Ij2iXbqRCUu4zWkvu/ZrJfaGOyT12Vhy1SLy0NMg==",
       "requires": {
         "firebase": "12.10.0"
-      }
-    },
-    "@react-native-firebase/auth": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-firebase/auth/-/auth-24.0.0.tgz",
-      "integrity": "sha512-LvjVouoTLx2yCkCSy5ZxfDrbZgxMIE5QIFfm2uqWXeP1L1+NVV3MkBMdKruhwIrF0nuLOuzvGdf545rUqRgN6Q==",
-      "requires": {
-        "plist": "^3.1.0"
       }
     },
     "@react-native-firebase/crashlytics": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-firebase/analytics": "^24.0.0",
     "@react-native-firebase/app": "^24.0.0",
-    "@react-native-firebase/auth": "^24.0.0",
     "@react-native-firebase/crashlytics": "^24.0.0",
     "@react-native-menu/menu": "^2.0.0",
     "@react-native-picker/picker": "2.11.4",


### PR DESCRIPTION
## What changed

- Removed `@react-native-firebase/auth` from `package.json` dependencies
- Removed `RNFBAuth` from the `expo-build-properties` `forceStaticLinking` array in `app.config.js`
- Regenerated `package-lock.json` (now contains zero references to the auth package)

## Why

No application code imports `firebase/auth` — verified there are no matches for `firebase/auth` or `auth()` anywhere under `src/`, `redux/`, or `App.tsx`. Dropping it removes an unused native module from the iOS/Android builds.

## Verification

- `npx tsc` — clean
- ESLint — clean (run with `--no-eslintrc -c .eslintrc.js` from the worktree to avoid a pre-existing config-cascade quirk; see note below)
- `npm test` — 38 suites, 365 tests, all passing
- `npx expo config --type prebuild` — evaluates successfully; resolved config shows `forceStaticLinking: ['RNFBApp', 'RNFBAnalytics', 'RNFBCrashlytics']`

## Reviewer note

Unrelated to this change: `.eslintrc.js` lacks `root: true`, so running ESLint from a git worktree nested under the main checkout fails with a duplicate `@typescript-eslint` plugin error as the config cascades to the parent repo. Worth a tiny follow-up if worktrees are part of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)