### PR TITLE
Allow game sheet to cover header

### DIFF
--- a/src/components/Sheets/GameSheet.test.tsx
+++ b/src/components/Sheets/GameSheet.test.tsx
@@ -32,6 +32,7 @@ jest.mock('@gorhom/bottom-sheet', () => {
         handleIndicatorStyle?: object;
         animatedPosition?: object;
         enablePanDownToClose?: boolean;
+        topInset?: number;
     }, ref: React.Ref<{ snapToIndex: (index: number) => void }>) => {
         useImperativeHandle(ref, () => ({
             snapToIndex: jest.fn((index: number) => {
@@ -40,7 +41,7 @@ jest.mock('@gorhom/bottom-sheet', () => {
         }));
         
         return (
-            <View testID="bottom-sheet" style={{ backgroundColor: 'rgb(30,40,50)' }}>
+            <View testID="bottom-sheet" style={{ backgroundColor: 'rgb(30,40,50)' }} topInset={props.topInset}>
                 {props.children}
             </View>
         );
@@ -289,6 +290,32 @@ describe('GameSheet', () => {
         expect(getByTestId('bottom-sheet')).toBeTruthy();
         expect(getByText('Test Game')).toBeTruthy();
         expect(getByTestId('score-log-table')).toBeTruthy();
+    });
+
+    it('should allow full expansion up to the top safe area', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: mockPlayers,
+                ids: ['player-1', 'player-2'],
+            },
+        });
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <GameSheet {...defaultProps} />
+            </Provider>
+        );
+
+        expect(getByTestId('bottom-sheet').props.topInset).toBe(50);
     });
 
     it('should show locked text when game is locked', () => {

--- a/src/components/Sheets/GameSheet.tsx
+++ b/src/components/Sheets/GameSheet.tsx
@@ -45,7 +45,7 @@ const GameSheet: React.FunctionComponent = () => {
     const dispatch = useAppDispatch();
 
     const insets = useSafeAreaInsets();
-    const topInset = insets.top + 50;
+    const topInset = insets.top;
 
     // Stable key for animated children to force remount on each mount
     const mountKey = useRef(Date.now()).current;


### PR DESCRIPTION
## Summary
- let the game sheet expand to the top safe-area inset instead of stopping at the header
- add a regression test for the BottomSheet topInset value

## Tests
- npm run test -- GameSheet --watchman=false --coverage=false

| Header | Header | Header | Header |
|--------|--------|--------|--------|
| Before | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-13 at 00 37 54" src="https://github.com/user-attachments/assets/73044bb8-a484-4ade-9e3b-17a773082ad1" /> | <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-13 at 00 26 32" src="https://github.com/user-attachments/assets/d7a63d03-6c45-492f-bf9e-344d4e13d3bc" /> | <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-13 at 00 26 29" src="https://github.com/user-attachments/assets/b455d098-9340-422c-8f0a-db63f92a4039" /> |
| After | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-13 at 00 30 55" src="https://github.com/user-attachments/assets/b4e0ab45-3a68-4338-9e3f-a85943aae2bf" /> | <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-13 at 00 30 45" src="https://github.com/user-attachments/assets/75e19c81-1e0e-4554-9eca-f2d830d17e62" /> | <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-13 at 00 30 42" src="https://github.com/user-attachments/assets/3b9f2e7a-7827-45f1-a47a-7d28d3c4019e" /> |

