### PR TITLE
Optimize ListBoard round change renders

### DIFF
--- a/src/components/Boards/ListBoard.test.tsx
+++ b/src/components/Boards/ListBoard.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
-import { fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
 import { Provider } from 'react-redux';
 
-import gamesReducer from '../../../redux/GamesSlice';
+import gamesReducer, { roundNext } from '../../../redux/GamesSlice';
 import playersReducer from '../../../redux/PlayersSlice';
 import settingsReducer, { toggleHomeFullscreen } from '../../../redux/SettingsSlice';
 
@@ -50,9 +50,18 @@ jest.mock('../MenuOpenContext', () => ({
 
 import ListBoard from './ListBoard';
 
-const createStore = (gameOverrides: Record<string, unknown> = {}, playerIds = ['player-1', 'player-2']) => {
+const createStore = (
+    gameOverrides: Record<string, unknown> = {},
+    playerIds = ['player-1', 'player-2'],
+    playerOverrides: Record<string, Record<string, unknown>> = {}
+) => {
     const players = Object.fromEntries(
-        playerIds.map((id) => [id, { id, playerName: `Player ${id.split('-')[1]}`, scores: [0] }])
+        playerIds.map((id) => [id, {
+            id,
+            playerName: `Player ${id.split('-')[1]}`,
+            scores: [0],
+            ...playerOverrides[id],
+        }])
     );
     return configureStore({
         reducer: { settings: settingsReducer, games: gamesReducer, players: playersReducer },
@@ -156,6 +165,47 @@ describe('ListBoard', () => {
                 paddingBottom: 44,
             })
         );
+    });
+
+    it('does not re-render player rows when advancing to an empty round keeps displayed row data unchanged', () => {
+        const store = createStore();
+        const onPlayerRowRender = jest.fn();
+
+        render(
+            <Provider store={store}><ListBoard showHint={false} onPlayerRowRender={onPlayerRowRender} /></Provider>
+        );
+
+        expect(onPlayerRowRender).toHaveBeenCalledTimes(2);
+        onPlayerRowRender.mockClear();
+
+        act(() => {
+            store.dispatch(roundNext('game-1'));
+        });
+
+        expect(onPlayerRowRender).not.toHaveBeenCalled();
+    });
+
+    it('only re-renders rows whose displayed score math changes on round advance', () => {
+        const store = createStore({}, ['player-1', 'player-2'], {
+            'player-1': { scores: [5] },
+            'player-2': { scores: [0] },
+        });
+        const onPlayerRowRender = jest.fn();
+
+        const { getAllByText } = render(
+            <Provider store={store}><ListBoard showHint={false} onPlayerRowRender={onPlayerRowRender} /></Provider>
+        );
+
+        expect(onPlayerRowRender).toHaveBeenCalledTimes(2);
+        onPlayerRowRender.mockClear();
+
+        act(() => {
+            store.dispatch(roundNext('game-1'));
+        });
+
+        expect(onPlayerRowRender).toHaveBeenCalledTimes(1);
+        expect(onPlayerRowRender).toHaveBeenCalledWith('player-1');
+        expect(getAllByText('5').length).toBeGreaterThanOrEqual(1);
     });
 });
 

--- a/src/components/Boards/ListBoard.tsx
+++ b/src/components/Boards/ListBoard.tsx
@@ -4,10 +4,10 @@ import { LayoutChangeEvent, LayoutRectangle, Pressable, ScrollView, StyleSheet, 
 import { Icon } from 'react-native-elements';
 import Animated, { Easing, SharedValue, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { shallowEqual } from 'react-redux';
 
+import { selectGameById } from '../../../redux/GamesSlice';
 import { useAppSelector } from '../../../redux/hooks';
-import { selectPlayerById, selectPlayerRoundStats } from '../../../redux/PlayersSlice';
-import { selectCurrentGame } from '../../../redux/selectors';
 import DialOverlay from '../Interactions/Dial/DialOverlay';
 import { useMenuOpen } from '../MenuOpenContext';
 import { bottomSheetHeight } from '../Sheets/GameSheet';
@@ -36,19 +36,44 @@ function inkA(ink: string, a: number): string {
 interface PlayerRowProps {
     playerId: string;
     index: number;
-    currentRoundIndex: number;
     svDimmed: SharedValue<boolean>;
     disabled: boolean;
     onRowPress: (id: string) => void;
+    onRender?: (id: string) => void;
 }
 
-const PlayerRow: React.FC<PlayerRowProps> = ({ playerId, index, currentRoundIndex, svDimmed, disabled, onRowPress }) => {
-    const player = useAppSelector((state) => selectPlayerById(state, playerId));
-    const currentGame = useAppSelector(selectCurrentGame);
-    const isWinner = !!(currentGame?.locked && currentGame?.winnerIds?.includes(playerId));
-    const { currentRoundScore, previousTotal, currentRoundTotalScore } = useAppSelector(
-        (state) => selectPlayerRoundStats(state, playerId, currentRoundIndex)
-    );
+const PlayerRow: React.FC<PlayerRowProps> = ({ playerId, index, svDimmed, disabled, onRowPress, onRender }) => {
+    onRender?.(playerId);
+
+    const {
+        playerName,
+        color,
+        locked,
+        isWinner,
+        currentRoundScore,
+        previousTotal,
+        currentRoundTotalScore,
+    } = useAppSelector((state) => {
+        const player = state.players.entities[playerId];
+        const currentGameId = state.settings.currentGameId;
+        const currentGame = currentGameId ? selectGameById(state, currentGameId) : undefined;
+        const currentRoundIndex = currentGame?.roundCurrent ?? 0;
+        const scores = player?.scores ?? [];
+        const currentRoundScore = scores[currentRoundIndex] ?? 0;
+        const previousTotal = scores.reduce(
+            (sum, s, i) => (i < currentRoundIndex ? sum + (s || 0) : sum), 0
+        );
+
+        return {
+            playerName: player?.playerName,
+            color: player?.color ?? '#555',
+            locked: currentGame?.locked === true,
+            isWinner: !!(currentGame?.locked && currentGame?.winnerIds?.includes(playerId)),
+            currentRoundScore,
+            previousTotal,
+            currentRoundTotalScore: previousTotal + currentRoundScore,
+        };
+    }, shallowEqual);
     const breakdownOpacity = useSharedValue(1);
 
     React.useEffect(() => {
@@ -60,9 +85,8 @@ const PlayerRow: React.FC<PlayerRowProps> = ({ playerId, index, currentRoundInde
     }));
     const breakdownStyle = useAnimatedStyle(() => ({ opacity: breakdownOpacity.value }));
 
-    if (!player) return null;
+    if (!playerName) return null;
 
-    const color = player.color ?? '#555';
     const ink = inkFor(color);
 
     const separatorSign = currentRoundScore < 0 ? '−' : '+';
@@ -104,12 +128,12 @@ const PlayerRow: React.FC<PlayerRowProps> = ({ playerId, index, currentRoundInde
                         numberOfLines={1}
                         adjustsFontSizeToFit
                         minimumFontScale={0.6}>
-                        {player.playerName}
+                        {playerName}
                     </Text>
 
                     {/* Score section */}
                     <View style={styles.scoreMath}>
-                        {currentGame?.locked ? (
+                        {locked ? (
                             /* Locked: hide PREV/RND, show winner pill in that slot */
                             isWinner && (
                                 <View style={styles.winnerBadge}>
@@ -145,8 +169,21 @@ const PlayerRow: React.FC<PlayerRowProps> = ({ playerId, index, currentRoundInde
 
 const MemoizedPlayerRow = React.memo(PlayerRow);
 
-const ListBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
-    const currentGame = useAppSelector(selectCurrentGame);
+interface ListBoardProps {
+    showHint: boolean;
+    onPlayerRowRender?: (id: string) => void;
+}
+
+const ListBoard: React.FC<ListBoardProps> = ({ showHint, onPlayerRowRender }) => {
+    const { playerIds, locked } = useAppSelector((state) => {
+        const currentGameId = state.settings.currentGameId;
+        const currentGame = currentGameId ? selectGameById(state, currentGameId) : undefined;
+
+        return {
+            playerIds: currentGame?.playerIds,
+            locked: currentGame?.locked === true,
+        };
+    }, shallowEqual);
     const fullscreen = useAppSelector(state => state.settings.home_fullscreen);
     const { menuOpen } = useMenuOpen();
     const insets = useSafeAreaInsets();
@@ -166,7 +203,7 @@ const ListBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
 
     const handleRowPress = useCallback(
         (id: string) => {
-            if (currentGame?.locked || menuOpen) return;
+            if (locked || menuOpen) return;
             if (!boardLayout) return;
             // Start entrance animation before React schedules the re-render so the
             // overlay is already mid-animation by the time it first paints.
@@ -176,17 +213,14 @@ const ListBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
             svOverlaySlideY.value = withTiming(0, { duration: 200, easing: Easing.out(Easing.cubic) });
             setSelectedId(id);
         },
-        [boardLayout, currentGame?.locked, menuOpen]
+        [boardLayout, locked, menuOpen]
     );
 
     const handleClose = useCallback(() => {
         setSelectedId(null);
     }, []);
 
-    if (!currentGame) return null;
-    const playerIds = currentGame.playerIds;
     if (!playerIds?.length) return null;
-    const currentRoundIndex = currentGame.roundCurrent;
     const scrollInsets = {
         bottom: fullscreen ? insets.bottom + 10 : bottomSheetHeight + 10,
         left: insets.left + ROW_BOARD_PADDING,
@@ -212,10 +246,10 @@ const ListBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
                         key={id}
                         playerId={id}
                         index={index}
-                        currentRoundIndex={currentRoundIndex}
                         svDimmed={svDimmed}
-                        disabled={!!(currentGame?.locked || menuOpen)}
+                        disabled={!!(locked || menuOpen)}
                         onRowPress={handleRowPress}
+                        onRender={onPlayerRowRender}
                     />
                 ))}
             </ScrollView>


### PR DESCRIPTION
## Summary
- isolate ListBoard subscriptions from roundCurrent so round changes do not invalidate every row prop
- move PlayerRow to a shallow-equal displayed row view model selector
- add render-count regression coverage for unchanged and changed row score math

## Tests
- npm run test -- ListBoard --watchman=false --coverage=false
- npm run test -- PlayersSlice --watchman=false --coverage=false
- npm run lint

| Before | After |
|--------|--------|
| <img width="1354" height="1078" alt="Screenshot 2026-06-13 at 12 52 44 AM" src="https://github.com/user-attachments/assets/194a28fd-82e6-4298-aa44-ce077dccdcd7" /> | <img width="1354" height="1078" alt="Screenshot 2026-06-13 at 12 57 55 AM" src="https://github.com/user-attachments/assets/75964bca-d3e6-484a-a1a1-9199de733ee6" /> | 




