### PR TITLE
Optimize TileBoard round change renders

### DIFF
--- a/redux/hooks.ts
+++ b/redux/hooks.ts
@@ -1,6 +1,7 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 
-import type { RootState, AppDispatch } from './store';
+import type { RootState, AppDispatch, AppStore } from './store';
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
+export const useAppStore = useStore.withTypes<AppStore>();

--- a/redux/store.ts
+++ b/redux/store.ts
@@ -88,6 +88,7 @@ export interface RootState {
 
 // Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
 export type AppDispatch = typeof store.dispatch;
+export type AppStore = typeof store;
 
 export const persistor = persistStore(store);
 

--- a/src/components/Boards/PlayerTile.tsx
+++ b/src/components/Boards/PlayerTile.tsx
@@ -1,11 +1,14 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
+import { getContrastRatio } from 'colorsheet';
 import { DimensionValue, StyleSheet } from 'react-native';
 import Animated, { Easing, FadeIn } from 'react-native-reanimated';
+import { shallowEqual } from 'react-redux';
 
-import { makeSelectPlayerColors } from '../../../redux/GamesSlice';
+import { selectGameById } from '../../../redux/GamesSlice';
 import { useAppSelector } from '../../../redux/hooks';
-import { selectCurrentGame, selectInteractionType } from '../../../redux/selectors';
+import { selectInteractionType } from '../../../redux/selectors';
+import { getPalette } from '../../ColorPalette';
 import { useTheme } from '../../theme';
 import { interactionComponents } from '../Interactions/InteractionComponents';
 import { InteractionType } from '../Interactions/InteractionType';
@@ -37,13 +40,25 @@ const PlayerTile: React.FunctionComponent<Props> = React.memo(({
     if (Number.isNaN(width) || Number.isNaN(height)) return null;
 
     const theme = useTheme();
-    const currentGame = useAppSelector(selectCurrentGame);
-    const currentGameId = currentGame?.id;
     const playerIndexLabel = useAppSelector(state => state.settings.showPlayerIndex);
-    const selectPlayerColors = useMemo(() => makeSelectPlayerColors(), []);
-    const playerColors = useAppSelector(state => selectPlayerColors(state, currentGameId, playerId));
-    const [bg, fg] = playerColors;
-    const isWinner = !!(currentGame?.locked && currentGame?.winnerIds?.includes(playerId));
+    const { bg, fg, isWinner } = useAppSelector(state => {
+        const currentGameId = state.settings.currentGameId;
+        const currentGame = currentGameId ? selectGameById(state, currentGameId) : undefined;
+        const palette = getPalette(currentGame?.palette || 'original') || getPalette('original');
+        const playerIndex = currentGame?.playerIds.indexOf(playerId) ?? 0;
+        const paletteBG = palette[playerIndex % palette.length];
+        const bg = state.players.entities[playerId]?.color || paletteBG;
+
+        const blackContrast = getContrastRatio(bg, '#000').number;
+        const whiteContrast = getContrastRatio(bg, '#fff').number;
+        const fg = blackContrast >= whiteContrast + 1 ? '#000000' : '#FFFFFF';
+
+        return {
+            bg,
+            fg,
+            isWinner: !!(currentGame?.locked && currentGame?.winnerIds?.includes(playerId)),
+        };
+    }, shallowEqual);
 
     const widthPerc: DimensionValue = `${(100 / cols)}%`;
     const heightPerc: DimensionValue = `${(100 / rows)}%`;

--- a/src/components/Boards/TileBoard.tsx
+++ b/src/components/Boards/TileBoard.tsx
@@ -3,8 +3,8 @@ import React, { memo, useEffect, useState } from 'react';
 import { LayoutChangeEvent, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { selectGameById } from '../../../redux/GamesSlice';
 import { useAppSelector } from '../../../redux/hooks';
-import { selectCurrentGame } from '../../../redux/selectors';
 import { bottomSheetHeight } from '../../components/Sheets/GameSheet';
 import { useTheme } from '../../theme';
 
@@ -13,7 +13,10 @@ import PlayerTile from './PlayerTile';
 const TileBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
     const theme = useTheme();
     const fullscreen = useAppSelector(state => state.settings.home_fullscreen);
-    const playerIds = useAppSelector(state => selectCurrentGame(state)?.playerIds);
+    const playerIds = useAppSelector(state => {
+        const currentGameId = state.settings.currentGameId;
+        return currentGameId ? selectGameById(state, currentGameId)?.playerIds : undefined;
+    });
 
     if (playerIds == null || playerIds.length == 0) return null;
 

--- a/src/components/Interactions/HalfTap/HalfTap.tsx
+++ b/src/components/Interactions/HalfTap/HalfTap.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import { selectGameById } from '../../../../redux/GamesSlice';
 import { useAppSelector } from '../../../../redux/hooks';
-import { selectPlayerById } from '../../../../redux/PlayersSlice';
-import { selectCurrentGame } from '../../../../redux/selectors';
 
 import { HalfTileTouchSurface } from './HalfTileTouchSurface';
 
@@ -13,6 +12,8 @@ interface HalfTapProps {
     fontColor: string;
     showHint?: boolean;
     tileHeight?: number;
+    /** Test-only render probe for selector invalidation regressions. */
+    onRender?: (id: string) => void;
 }
 
 const HINT_MIN_HEIGHT = 200;
@@ -24,13 +25,18 @@ const HalfTap: React.FC<HalfTapProps> = ({
     playerId,
     showHint,
     tileHeight,
+    onRender,
 }) => {
-    const hintVisible = showHint && (!tileHeight || tileHeight >= HINT_MIN_HEIGHT);
-    const currentGame = useAppSelector(selectCurrentGame);
-    if (typeof currentGame == 'undefined') return null;
+    onRender?.(playerId);
 
-    const player = useAppSelector(state => selectPlayerById(state, playerId));
-    if (typeof player == 'undefined') return null;
+    const hintVisible = showHint && (!tileHeight || tileHeight >= HINT_MIN_HEIGHT);
+    const hasCurrentGame = useAppSelector(state => {
+        const currentGameId = state.settings.currentGameId;
+        return currentGameId ? typeof selectGameById(state, currentGameId) !== 'undefined' : false;
+    });
+    const hasPlayer = useAppSelector(state => typeof state.players.entities[playerId] !== 'undefined');
+
+    if (!hasCurrentGame || !hasPlayer) return null;
 
     return (
         <>

--- a/src/components/Interactions/HalfTap/HalfTileTouchSurface.test.tsx
+++ b/src/components/Interactions/HalfTap/HalfTileTouchSurface.test.tsx
@@ -2,12 +2,15 @@
 import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
-import { fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { TouchableHighlight } from 'react-native';
 import { Provider } from 'react-redux';
 
-import { playerRoundScoreIncrement } from '../../../../redux/PlayersSlice';
+import gamesReducer, { roundNext } from '../../../../redux/GamesSlice';
+import playersReducer, { playerRoundScoreIncrement } from '../../../../redux/PlayersSlice';
+import settingsReducer, { initialState as settingsInitialState } from '../../../../redux/SettingsSlice';
 
+import HalfTap from './HalfTap';
 import { HalfTileTouchSurface } from './HalfTileTouchSurface';
 
 jest.mock('../../../Analytics', () => ({ logEvent: function () { } }));
@@ -24,8 +27,6 @@ jest.mock('../../MenuOpenContext', () => ({
   useMenuOpen: function () { return { menuOpen: mockMenuOpen, setMenuOpen: function () { } }; },
 }));
 
-const stub = function (s: any = {}) { return s; };
-
 beforeEach(() => {
   mockMenuOpen = false;
 });
@@ -34,13 +35,14 @@ type RenderOptions = {
   scoreType?: 'increment' | 'decrement';
   roundCurrent?: number;
   locked?: boolean;
+  onRender?: (id: string) => void;
 };
 
-const renderSurface = ({ scoreType = 'increment', roundCurrent = 0, locked = false }: RenderOptions = {}) => {
+const renderSurface = ({ scoreType = 'increment', roundCurrent = 0, locked = false, onRender }: RenderOptions = {}) => {
   const store = configureStore({
-    reducer: { settings: stub, games: stub, players: stub },
+    reducer: { settings: settingsReducer, games: gamesReducer, players: playersReducer },
     preloadedState: {
-      settings: { addendOne: 3, addendTwo: 10, currentGameId: 'game-1', multiplier: '1', onboarded: null, interactionType: null, showPointParticles: true, _persist: { version: 0, rehydrated: true } },
+      settings: { ...settingsInitialState, addendOne: 3, addendTwo: 10, currentGameId: 'game-1', showPointParticles: true },
       games: { ids: ['game-1'], entities: { 'game-1': { id: 'game-1', title: 'Test', dateCreated: Date.now(), roundCurrent, roundTotal: roundCurrent + 1, locked, playerIds: ['player-1'] } }, _persist: { version: 0, rehydrated: true } },
       players: { ids: ['player-1'], entities: { 'player-1': { id: 'player-1', playerName: 'Test', scores: [0] } }, _persist: { version: 0, rehydrated: true } },
     },
@@ -48,11 +50,32 @@ const renderSurface = ({ scoreType = 'increment', roundCurrent = 0, locked = fal
   const dispatch = jest.spyOn(store, 'dispatch');
   const utils = render(
     <Provider store={store}>
-      <HalfTileTouchSurface playerIndex={0} playerId="player-1" fontColor="white" scoreType={scoreType} />
+      <HalfTileTouchSurface playerIndex={0} playerId="player-1" fontColor="white" scoreType={scoreType} onRender={onRender} />
     </Provider>
   );
   const surface = utils.UNSAFE_getByType(TouchableHighlight);
-  return { dispatch, surface };
+  return { dispatch, store, surface };
+};
+
+const renderHalfTap = ({ onRender }: { onRender?: (id: string) => void; } = {}) => {
+  const store = configureStore({
+    reducer: { settings: settingsReducer, games: gamesReducer, players: playersReducer },
+    preloadedState: {
+      settings: { ...settingsInitialState, currentGameId: 'game-1' },
+      games: { ids: ['game-1'], entities: { 'game-1': { id: 'game-1', title: 'Test', dateCreated: Date.now(), roundCurrent: 0, roundTotal: 1, locked: false, playerIds: ['player-1'] } }, _persist: { version: 0, rehydrated: true } },
+      players: { ids: ['player-1'], entities: { 'player-1': { id: 'player-1', playerName: 'Test', scores: [0] } }, _persist: { version: 0, rehydrated: true } },
+    },
+  });
+
+  render(
+    <Provider store={store}>
+      <HalfTap index={0} playerId="player-1" fontColor="white" onRender={onRender}>
+        <></>
+      </HalfTap>
+    </Provider>
+  );
+
+  return { store };
 };
 
 describe('HalfTileTouchSurface', () => {
@@ -96,6 +119,35 @@ describe('HalfTileTouchSurface', () => {
     );
   });
 
+  it('does not re-render solely because the current round changes', () => {
+    const onRender = jest.fn();
+    const { store } = renderSurface({ onRender });
+
+    expect(onRender).toHaveBeenCalledTimes(1);
+    onRender.mockClear();
+
+    act(() => {
+      store.dispatch(roundNext('game-1'));
+    });
+
+    expect(onRender).not.toHaveBeenCalled();
+  });
+
+  it('targets the latest round after a round change', () => {
+    const { dispatch, store, surface } = renderSurface();
+
+    act(() => {
+      store.dispatch(roundNext('game-1'));
+    });
+    dispatch.mockClear();
+
+    fireEvent.press(surface);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      playerRoundScoreIncrement('player-1', 1, 3)
+    );
+  });
+
   it('does not dispatch when the game is locked', () => {
     const { dispatch, surface } = renderSurface({ locked: true });
     fireEvent.press(surface);
@@ -109,5 +161,21 @@ describe('HalfTileTouchSurface', () => {
     fireEvent.press(surface);
     fireEvent(surface, 'longPress');
     expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('HalfTap', () => {
+  it('does not re-render solely because the current round changes', () => {
+    const onRender = jest.fn();
+    const { store } = renderHalfTap({ onRender });
+
+    expect(onRender).toHaveBeenCalledTimes(1);
+    onRender.mockClear();
+
+    act(() => {
+      store.dispatch(roundNext('game-1'));
+    });
+
+    expect(onRender).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Interactions/HalfTap/HalfTileTouchSurface.tsx
+++ b/src/components/Interactions/HalfTap/HalfTileTouchSurface.tsx
@@ -3,9 +3,9 @@ import React, { useState } from 'react';
 import * as Haptics from 'expo-haptics';
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
-import { useAppDispatch, useAppSelector } from '../../../../redux/hooks';
+import { selectGameById } from '../../../../redux/GamesSlice';
+import { useAppDispatch, useAppSelector, useAppStore } from '../../../../redux/hooks';
 import { playerRoundScoreIncrement } from '../../../../redux/PlayersSlice';
-import { selectCurrentGame } from '../../../../redux/selectors';
 import { logEvent } from '../../../Analytics';
 import { useMenuOpen } from '../../MenuOpenContext';
 import { ScoreParticle } from '../../PlayerTiles/AdditionTile/ScoreParticle';
@@ -21,14 +21,18 @@ type Props = {
     fontColor: string;
     scoreType: 'increment' | 'decrement';
     showHint?: boolean;
+    /** Test-only render probe for selector invalidation regressions. */
+    onRender?: (id: string) => void;
 };
 
 export const HalfTileTouchSurface: React.FunctionComponent<Props> = (
-    { playerIndex, fontColor, playerId, scoreType, showHint }: Props) => {
+    { playerIndex, fontColor, playerId, scoreType, showHint, onRender }: Props) => {
+    onRender?.(playerId);
 
     const { menuOpen } = useMenuOpen();
     const showPointParticles = useAppSelector(state => state.settings.showPointParticles);
     const dispatch = useAppDispatch();
+    const store = useAppStore();
 
     const [particles, setParticles] = useState<ScoreParticleProps[]>([]);
 
@@ -36,10 +40,21 @@ export const HalfTileTouchSurface: React.FunctionComponent<Props> = (
     const addendTwo = useAppSelector(state => state.settings.addendTwo);
 
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
-    const currentGame = useAppSelector(selectCurrentGame);
-    if (typeof currentGame == 'undefined') return null;
+    const currentGameLocked = useAppSelector(state => {
+        const currentGameId = state.settings.currentGameId;
+        return currentGameId ? selectGameById(state, currentGameId)?.locked === true : false;
+    });
+    const hasCurrentGame = useAppSelector(state => {
+        const currentGameId = state.settings.currentGameId;
+        return currentGameId ? typeof selectGameById(state, currentGameId) !== 'undefined' : false;
+    });
+    if (!hasCurrentGame) return null;
 
-    const currentRoundIndex = currentGame.roundCurrent;
+    const getCurrentRoundIndex = () => {
+        const state = store.getState();
+        const currentGameId = state.settings.currentGameId;
+        return currentGameId ? selectGameById(state, currentGameId)?.roundCurrent ?? 0 : 0;
+    };
 
     const addParticle = (addend: number) => {
         const key = Math.random().toString(36).substring(7);
@@ -52,8 +67,9 @@ export const HalfTileTouchSurface: React.FunctionComponent<Props> = (
     };
 
     const scoreChangeHandler = (addend: number, secondaryHold = false) => {
-        if (currentGame.locked) return;
+        if (currentGameLocked) return;
         if (menuOpen) return;
+        const currentRoundIndex = getCurrentRoundIndex();
 
         if (showPointParticles) {
             addParticle(addend);
@@ -74,7 +90,7 @@ export const HalfTileTouchSurface: React.FunctionComponent<Props> = (
     return (
         <TouchableHighlight
             style={[styles.surface, scoreType == 'increment' ? styles.surfaceAdd : styles.surfaceSubtract]}
-            underlayColor={currentGame.locked || menuOpen ? 'transparent' : fontColor + '30'}
+            underlayColor={currentGameLocked || menuOpen ? 'transparent' : fontColor + '30'}
             activeOpacity={menuOpen ? 1 : 1}
             onPress={() => scoreChangeHandler(addendOne)}
             onLongPress={() => scoreChangeHandler(addendTwo, true)}>

--- a/src/components/Interactions/Swipe/Swipe.test.tsx
+++ b/src/components/Interactions/Swipe/Swipe.test.tsx
@@ -5,7 +5,9 @@ import { configureStore } from '@reduxjs/toolkit';
 import { act, render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 
-import { playerRoundScoreIncrement } from '../../../../redux/PlayersSlice';
+import gamesReducer, { roundNext } from '../../../../redux/GamesSlice';
+import playersReducer, { playerRoundScoreIncrement } from '../../../../redux/PlayersSlice';
+import settingsReducer, { initialState as settingsInitialState } from '../../../../redux/SettingsSlice';
 
 import SwipeVertical from './Swipe';
 
@@ -52,19 +54,17 @@ jest.mock('react-native-gesture-handler', () => ({
   State: {},
 }));
 
-const stub = function (s: any = {}) { return s; };
-
 beforeEach(() => {
   (globalThis as any).__ph = {};
   (globalThis as any).__react = undefined;
   jest.useRealTimers();
 });
 
-const renderSwipe = () => {
+const renderSwipe = ({ onRender }: { onRender?: (id: string) => void; } = {}) => {
   const store = configureStore({
-    reducer: { settings: stub, games: stub, players: stub },
+    reducer: { settings: settingsReducer, games: gamesReducer, players: playersReducer },
     preloadedState: {
-      settings: { addendOne: 1, addendTwo: 10, currentGameId: 'game-1', multiplier: '1', onboarded: null, interactionType: null, showPointParticles: true, _persist: { version: 0, rehydrated: true } },
+      settings: { ...settingsInitialState, addendOne: 1, addendTwo: 10, currentGameId: 'game-1', showPointParticles: true },
       games: { ids: ['game-1'], entities: { 'game-1': { id: 'game-1', title: 'Test', dateCreated: Date.now(), roundCurrent: 0, roundTotal: 1, locked: false, playerIds: ['player-1'] } }, _persist: { version: 0, rehydrated: true } },
       players: { ids: ['player-1'], entities: { 'player-1': { id: 'player-1', playerName: 'Test', scores: [0] } }, _persist: { version: 0, rehydrated: true } },
     },
@@ -72,10 +72,10 @@ const renderSwipe = () => {
   const dispatch = jest.spyOn(store, 'dispatch');
   render(
     <Provider store={store}>
-      <SwipeVertical fontColor="white" index={0} playerId="player-1"><></></SwipeVertical>
+      <SwipeVertical fontColor="white" index={0} playerId="player-1" onRender={onRender}><></></SwipeVertical>
     </Provider>
   );
-  return { dispatch };
+  return { dispatch, store };
 };
 
 const triggerReaction = (totalOffset: number, prevTotalOffset: number) => {
@@ -183,6 +183,42 @@ describe('SwipeVertical', () => {
 
     expect(dispatch).toHaveBeenCalledWith(
       playerRoundScoreIncrement('player-1', 0, 2)
+    );
+  });
+
+  it('does not re-render solely because the current round changes', () => {
+    const onRender = jest.fn();
+    const { store } = renderSwipe({ onRender });
+
+    expect(onRender).toHaveBeenCalledTimes(1);
+    onRender.mockClear();
+
+    act(() => {
+      store.dispatch(roundNext('game-1'));
+    });
+
+    expect(onRender).not.toHaveBeenCalled();
+  });
+
+  it('scores against the latest round after a round change', () => {
+    const { dispatch, store } = renderSwipe();
+    const ph = (globalThis as any).__ph;
+
+    act(() => {
+      store.dispatch(roundNext('game-1'));
+    });
+    dispatch.mockClear();
+
+    ph.onBegin();
+    ph.onUpdate({ translationY: -100 });
+    triggerReaction(100, 0);
+    act(() => {
+      ph.onEnd({ translationY: -100 });
+      ph.onFinalize();
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      playerRoundScoreIncrement('player-1', 1, 2)
     );
   });
 });

--- a/src/components/Interactions/Swipe/Swipe.tsx
+++ b/src/components/Interactions/Swipe/Swipe.tsx
@@ -5,9 +5,9 @@ import { Animated, StyleSheet, Text, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import ReAnimated, { runOnJS, useAnimatedReaction, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
-import { useAppDispatch, useAppSelector } from '../../../../redux/hooks';
+import { selectGameById } from '../../../../redux/GamesSlice';
+import { useAppDispatch, useAppSelector, useAppStore } from '../../../../redux/hooks';
 import { playerRoundScoreIncrement } from '../../../../redux/PlayersSlice';
-import { selectCurrentGame } from '../../../../redux/selectors';
 import { logEvent } from '../../../Analytics';
 import { useMenuOpen } from '../../MenuOpenContext';
 
@@ -18,6 +18,7 @@ interface HalfTapProps {
     playerId: string;
     showHint?: boolean;
     tileHeight?: number;
+    onRender?: (id: string) => void;
 }
 
 const notchSize = 50;
@@ -31,15 +32,21 @@ const SwipeVertical: React.FC<HalfTapProps> = ({
     fontColor,
     showHint,
     tileHeight,
+    onRender,
 }) => {
+    onRender?.(playerId);
+
     const hintVisible = showHint && (!tileHeight || tileHeight >= HINT_MIN_HEIGHT);
     //#region Selector setup
 
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
-    const currentRoundIndex = useAppSelector(state => selectCurrentGame(state)?.roundCurrent) || 0;
-    const currentGameLocked = useAppSelector(state => selectCurrentGame(state)?.locked);
+    const currentGameLocked = useAppSelector(state => {
+        const currentGameId = state.settings.currentGameId;
+        return currentGameId ? selectGameById(state, currentGameId)?.locked === true : false;
+    });
 
     const dispatch = useAppDispatch();
+    const store = useAppStore();
 
     const addendOne = useAppSelector(state => state.settings.addendOne);
     const addendTwo = useAppSelector(state => state.settings.addendTwo);
@@ -136,20 +143,26 @@ const SwipeVertical: React.FC<HalfTapProps> = ({
 
     const { menuOpen } = useMenuOpen();
 
+    const getCurrentRoundIndex = useCallback(() => {
+        const state = store.getState();
+        const currentGameId = state.settings.currentGameId;
+        return currentGameId ? selectGameById(state, currentGameId)?.roundCurrent ?? 0 : 0;
+    }, [store]);
+
     const endGesture = useCallback((translationY: number) => {
         if (menuOpen) return;
         logEvent('score_change', {
             player_index: index,
             game_id: currentGameId,
             addend: secondaryHold ? addendTwo : addendOne,
-            round: currentRoundIndex,
+            round: getCurrentRoundIndex(),
             type: translationY > 0 ? 'decrement' : 'increment',
             power_hold: secondaryHold,
             notches: -Math.round((translationY || 0) / notchSize),
             interaction: 'swipe-vertical',
         });
         secondaryHoldStop();
-    }, [index, currentGameId, secondaryHold, addendOne, addendTwo, currentRoundIndex, menuOpen]);
+    }, [index, currentGameId, secondaryHold, addendOne, addendTwo, getCurrentRoundIndex, menuOpen]);
 
     const panGesture = Gesture.Pan()
         .enabled(!currentGameLocked && !menuOpen)
@@ -188,6 +201,7 @@ const SwipeVertical: React.FC<HalfTapProps> = ({
         if (menuOpen) return;
 
         const scoreDelta = value * (secondaryHold ? addendTwo : addendOne);
+        const currentRoundIndex = getCurrentRoundIndex();
 
         if (secondaryHold) {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);

--- a/src/components/Interactions/Swipe/Swipe.tsx
+++ b/src/components/Interactions/Swipe/Swipe.tsx
@@ -18,6 +18,7 @@ interface HalfTapProps {
     playerId: string;
     showHint?: boolean;
     tileHeight?: number;
+    /** Test-only render probe for selector invalidation regressions. */
     onRender?: (id: string) => void;
 }
 

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.test.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
-import { render } from '@testing-library/react-native';
+import { act, render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 
-import gamesReducer from '../../../../redux/GamesSlice';
+import gamesReducer, { roundNext } from '../../../../redux/GamesSlice';
 import playersReducer from '../../../../redux/PlayersSlice';
 import settingsReducer from '../../../../redux/SettingsSlice';
 
@@ -480,5 +480,94 @@ describe('AdditionTile', () => {
                 </Provider>
             );
         }).not.toThrow();
+    });
+
+    it('does not re-render when advancing to an empty round keeps displayed score data unchanged', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': {
+                        ...mockGame,
+                        roundCurrent: 0,
+                        roundTotal: 1,
+                    },
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: {
+                    'player-1': {
+                        ...mockPlayer,
+                        scores: [0],
+                    },
+                },
+                ids: ['player-1'],
+            },
+        });
+        const onRender = jest.fn();
+
+        render(
+            <Provider store={store}>
+                <AdditionTile {...defaultProps} onRender={onRender} />
+            </Provider>
+        );
+
+        expect(onRender).toHaveBeenCalledTimes(1);
+        onRender.mockClear();
+
+        act(() => {
+            store.dispatch(roundNext('game-1'));
+        });
+
+        expect(onRender).not.toHaveBeenCalled();
+    });
+
+    it('re-renders when advancing rounds changes displayed score math', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': {
+                        ...mockGame,
+                        roundCurrent: 0,
+                        roundTotal: 1,
+                    },
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: {
+                    'player-1': {
+                        ...mockPlayer,
+                        scores: [5],
+                    },
+                },
+                ids: ['player-1'],
+            },
+        });
+        const onRender = jest.fn();
+
+        const { getByText } = render(
+            <Provider store={store}>
+                <AdditionTile {...defaultProps} onRender={onRender} />
+            </Provider>
+        );
+
+        expect(onRender).toHaveBeenCalledTimes(1);
+        onRender.mockClear();
+
+        act(() => {
+            store.dispatch(roundNext('game-1'));
+        });
+
+        expect(onRender).toHaveBeenCalledTimes(1);
+        expect(getByText('Before: 5')).toBeTruthy();
+        expect(getByText('Round: 0')).toBeTruthy();
+        expect(getByText('After: 5')).toBeTruthy();
     });
 });

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
@@ -19,6 +19,7 @@ interface Props {
     maxHeight: number | null;
     playerId: string;
     index: number;
+    /** Test-only render probe for selector invalidation regressions. */
     onRender?: (id: string) => void;
 }
 

--- a/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
+++ b/src/components/PlayerTiles/AdditionTile/AdditionTile.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import { StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { shallowEqual } from 'react-redux';
 
+import { selectGameById } from '../../../../redux/GamesSlice';
 import { useAppSelector } from '../../../../redux/hooks';
-import { selectPlayerById, selectPlayerRoundStats } from '../../../../redux/PlayersSlice';
-import { selectCurrentGame } from '../../../../redux/selectors';
 
 import { calculateFontSize } from './Helpers';
 import ScoreAfter from './ScoreAfter';
@@ -19,6 +19,7 @@ interface Props {
     maxHeight: number | null;
     playerId: string;
     index: number;
+    onRender?: (id: string) => void;
 }
 
 const AdditionTile: React.FunctionComponent<Props> = ({
@@ -26,19 +27,40 @@ const AdditionTile: React.FunctionComponent<Props> = ({
     maxWidth,
     maxHeight,
     playerId,
+    onRender,
 }) => {
-    const currentGame = useAppSelector(selectCurrentGame);
-    if (typeof currentGame == 'undefined') return null;
+    onRender?.(playerId);
 
-    const currentRoundIndex = currentGame.roundCurrent;
-    const isLocked = currentGame.locked === true;
+    const {
+        currentRoundScore,
+        currentRoundTotalScore,
+        grandTotalScore,
+        hasCurrentGame,
+        isLocked,
+        playerName,
+    } = useAppSelector(state => {
+        const currentGameId = state.settings.currentGameId;
+        const currentGame = currentGameId ? selectGameById(state, currentGameId) : undefined;
+        const player = state.players.entities[playerId];
+        const scores = player?.scores ?? [];
+        const currentRoundIndex = currentGame?.roundCurrent ?? 0;
+        const currentRoundScore = scores[currentRoundIndex] ?? 0;
+        const previousTotal = scores.reduce(
+            (sum, s, i) => (i < currentRoundIndex ? sum + (s || 0) : sum), 0
+        );
 
-    const player = useAppSelector(state => selectPlayerById(state, playerId));
-    if (typeof player == 'undefined') return null;
-    const playerName = player.playerName;
-    const { currentRoundScore, currentRoundTotalScore, grandTotalScore } = useAppSelector(
-        state => selectPlayerRoundStats(state, playerId, currentRoundIndex)
-    );
+        return {
+            currentRoundScore,
+            currentRoundTotalScore: previousTotal + currentRoundScore,
+            grandTotalScore: scores.reduce((sum, s) => sum + (s || 0), 0),
+            hasCurrentGame: typeof currentGame !== 'undefined',
+            isLocked: currentGame?.locked === true,
+            playerName: player?.playerName,
+        };
+    }, shallowEqual);
+
+    if (!hasCurrentGame) return null;
+    if (typeof playerName == 'undefined') return null;
 
     if (maxWidth == null || maxHeight == null) return null;
 


### PR DESCRIPTION
## Summary
- isolate TileBoard, PlayerTile, and AdditionTile selectors from whole current-game updates
- read SwipeVertical round state at gesture time so round changes do not re-render every swipe surface
- apply the same event-time round lookup to HalfTap/HalfTileTouchSurface so tap surfaces do not re-render on round changes
- add regression coverage for tile render isolation, swipe/tap render isolation, and latest-round scoring after round changes

## Tests
- npm run test -- TileBoard --watchman=false --coverage=false
- npm run test -- AdditionTile --watchman=false --coverage=false
- npm run test -- Swipe --watchman=false --coverage=false
- npm run test -- HalfTileTouchSurface --watchman=false --coverage=false
- npm run lint

| Before | After |
|--------|--------|
| <img width="1354" height="1078" alt="Screenshot 2026-06-13 at 1 04 35 AM" src="https://github.com/user-attachments/assets/c7e1612a-c7b3-4ef4-969e-d9fd07b99f29" /> | <img width="1354" height="1078" alt="Screenshot 2026-06-13 at 1 12 37 AM" src="https://github.com/user-attachments/assets/9e3ead2c-1000-4360-b192-04842e750262" /> | 