### PR TITLE
Stabilize ListBoard row press callback to avoid full re-renders on open

### DIFF
--- a/src/components/Boards/ListBoard.tsx
+++ b/src/components/Boards/ListBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 import { LayoutChangeEvent, LayoutRectangle, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements';
@@ -189,6 +189,12 @@ const ListBoard: React.FC<ListBoardProps> = ({ showHint, onPlayerRowRender }) =>
     const insets = useSafeAreaInsets();
     const [selectedId, setSelectedId] = useState<string | null>(null);
     const [boardLayout, setBoardLayout] = useState<LayoutRectangle | null>(null);
+    // Mirror boardLayout in a ref so handleRowPress can read the latest layout
+    // without depending on the state value. Otherwise every onLayout pass (the
+    // layout settles in multiple passes on first open) would recreate the
+    // callback, change the onRowPress prop on every memoized row, and force the
+    // entire row list to re-render.
+    const boardLayoutRef = useRef<LayoutRectangle | null>(null);
     const svDimmed = useSharedValue(false);
     const svOverlayOpacity = useSharedValue(0);
     const svOverlaySlideY = useSharedValue(20);
@@ -198,13 +204,14 @@ const ListBoard: React.FC<ListBoardProps> = ({ showHint, onPlayerRowRender }) =>
     }, [selectedId]);
 
     const handleBoardLayout = useCallback((e: LayoutChangeEvent) => {
+        boardLayoutRef.current = e.nativeEvent.layout;
         setBoardLayout(e.nativeEvent.layout);
     }, []);
 
     const handleRowPress = useCallback(
         (id: string) => {
             if (locked || menuOpen) return;
-            if (!boardLayout) return;
+            if (!boardLayoutRef.current) return;
             // Start entrance animation before React schedules the re-render so the
             // overlay is already mid-animation by the time it first paints.
             svOverlayOpacity.value = 0;
@@ -213,7 +220,7 @@ const ListBoard: React.FC<ListBoardProps> = ({ showHint, onPlayerRowRender }) =>
             svOverlaySlideY.value = withTiming(0, { duration: 200, easing: Easing.out(Easing.cubic) });
             setSelectedId(id);
         },
-        [boardLayout, locked, menuOpen]
+        [locked, menuOpen]
     );
 
     const handleClose = useCallback(() => {


### PR DESCRIPTION
## Problem

Profiling a first-open of the ListBoard (React DevTools) showed **two full re-renders of the entire ListBoard subtree** right after mount:

| Commit | Duration | What rendered | Scheduled by |
|--------|----------|---------------|--------------|
| 3 | 159ms | Entire ListBoard subtree (~1205 fibers) | ListBoard |
| 5 | 121ms | Identical ListBoard subtree again (~1205 fibers) | ListBoard |

That's ~280ms of avoidable work (~50 player rows × ~24 elements each, re-rendered twice).

## Root cause

`handleRowPress` was a `useCallback` with `boardLayout` in its dependency array. On first open the container's layout settles in **multiple `onLayout` passes** (initial mount, then again after the GameSheet bottom sheet mounts and changes available height). Each `setBoardLayout`:

1. recreated `handleRowPress` with a new identity,
2. which changed the `onRowPress` prop on every `MemoizedPlayerRow`,
3. defeating `React.memo` and forcing all rows to re-render — twice.

The rows were already correctly memoized; the unstable callback was busting it.

## Fix

Mirror `boardLayout` into a `useRef` and read `boardLayoutRef.current` inside `handleRowPress`, removing `boardLayout` from its dependency array. The callback now keeps a stable identity across layout passes, so the rows bail out of `React.memo`. The `boardLayout` state is retained only for rendering `DialOverlay`'s dimensions (fresh at press time, so rotation still works).

Each layout pass now re-renders only `ListBoard` itself (a handful of fibers) instead of the full ~1205-fiber subtree.

## Testing

- All 12 `ListBoard.test.tsx` tests pass (including the row-press → DialOverlay path this change touches).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)