### PR TITLE
Optimize TileBoard initial load

### DIFF
--- a/src/components/Boards/PlayerTile.tsx
+++ b/src/components/Boards/PlayerTile.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { getContrastRatio } from 'colorsheet';
 import { DimensionValue, StyleSheet } from 'react-native';
-import Animated, { Easing, FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { shallowEqual } from 'react-redux';
 
 import { selectGameById } from '../../../redux/GamesSlice';
@@ -69,7 +69,6 @@ const PlayerTile: React.FunctionComponent<Props> = React.memo(({
 
     return (
         <Animated.View
-            entering={FadeIn.delay(25 * index + 50).duration(400).easing(Easing.ease)}
             style={[
                 styles.playerCard,
                 {

--- a/src/components/Boards/TileBoard.test.tsx
+++ b/src/components/Boards/TileBoard.test.tsx
@@ -13,7 +13,7 @@ jest.mock('../Sheets/GameSheet', () => ({
     bottomSheetHeight: 80,
 }));
 
-import TileBoard from './TileBoard';
+import TileBoard, { calculateTileBoardLayout, calculateTileDimensions } from './TileBoard';
 
 // Mock react-native-safe-area-context
 jest.mock('react-native-safe-area-context', () => ({
@@ -78,6 +78,22 @@ const createMockStore = (initialState: Parameters<typeof configureStore>[0]['pre
         },
         preloadedState: initialState,
     });
+};
+
+const fireBoardLayout = (element: ReturnType<ReturnType<typeof render>['getByTestId']>, width: number, height: number) => {
+    fireEvent(element, 'layout', {
+        nativeEvent: {
+            layout: {
+                height,
+                width,
+            },
+        },
+    });
+};
+
+const fireSettledBoardLayout = (element: ReturnType<ReturnType<typeof render>['getByTestId']>, width: number, height: number) => {
+    fireBoardLayout(element, width, height);
+    fireBoardLayout(element, width, height);
 };
 
 describe('TileBoard', () => {
@@ -224,7 +240,35 @@ describe('TileBoard', () => {
         expect(queryByTestId('player-tile-player-1')).toBeNull();
     });
 
-    it('should render tiles after layout event with calculated grid', () => {
+    it('should not render tiles from the first layout measurement', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: mockPlayers,
+                ids: ['player-1', 'player-2', 'player-3', 'player-4'],
+            },
+        });
+
+        const { getByTestId, queryByTestId } = render(
+            <Provider store={store}>
+                <TileBoard showHint={false} />
+            </Provider>
+        );
+
+        fireBoardLayout(getByTestId('safe-area-view'), 400, 600);
+
+        expect(queryByTestId('player-tile-player-1')).toBeNull();
+    });
+
+    it('should render tiles after settled layout with calculated grid', () => {
         const store = createMockStore({
             settings: {
                 currentGameId: 'game-1',
@@ -250,14 +294,7 @@ describe('TileBoard', () => {
         const safeAreaView = getByTestId('safe-area-view');
         
         // Trigger layout event with specific dimensions
-        fireEvent(safeAreaView, 'layout', {
-            nativeEvent: {
-                layout: {
-                    width: 400,
-                    height: 600,
-                },
-            },
-        });
+        fireSettledBoardLayout(safeAreaView, 400, 600);
 
         // After layout, tiles should be rendered
         expect(getByTestId('player-tile-player-1')).toBeTruthy();
@@ -296,14 +333,7 @@ describe('TileBoard', () => {
         const safeAreaView = getByTestId('safe-area-view');
         
         // Trigger layout with 400x600 dimensions
-        fireEvent(safeAreaView, 'layout', {
-            nativeEvent: {
-                layout: {
-                    width: 400,
-                    height: 600,
-                },
-            },
-        });
+        fireSettledBoardLayout(safeAreaView, 400, 600);
 
         // For 2x2 grid: width = 400/2 = 200, height = 600/2 = 300
         expect(getAllByText('Width: 200')).toHaveLength(4);
@@ -339,14 +369,7 @@ describe('TileBoard', () => {
         const safeAreaView = getByTestId('safe-area-view');
         
         // Trigger layout event
-        fireEvent(safeAreaView, 'layout', {
-            nativeEvent: {
-                layout: {
-                    width: 300,
-                    height: 400,
-                },
-            },
-        });
+        fireSettledBoardLayout(safeAreaView, 300, 400);
 
         // For 3 players, should calculate optimal grid (likely 3x1 or 1x3)
         expect(getByTestId('player-tile-player-1')).toBeTruthy();
@@ -388,14 +411,7 @@ describe('TileBoard', () => {
 
         const safeAreaView = getByTestId('safe-area-view');
         
-        fireEvent(safeAreaView, 'layout', {
-            nativeEvent: {
-                layout: {
-                    width: 300,
-                    height: 400,
-                },
-            },
-        });
+        fireSettledBoardLayout(safeAreaView, 300, 400);
 
         expect(getByTestId('player-tile-player-1')).toBeTruthy();
         // Single player should be 1x1 grid
@@ -463,14 +479,7 @@ describe('TileBoard', () => {
 
         const safeAreaView = getByTestId('safe-area-view');
         
-        fireEvent(safeAreaView, 'layout', {
-            nativeEvent: {
-                layout: {
-                    width: 400,
-                    height: 400,
-                },
-            },
-        });
+        fireSettledBoardLayout(safeAreaView, 400, 400);
 
         // Check that each tile has the correct index
         expect(getByText('Index: 0')).toBeTruthy(); // player-1
@@ -508,29 +517,50 @@ describe('TileBoard', () => {
         const safeAreaView = getByTestId('safe-area-view');
         
         // Initial layout
-        fireEvent(safeAreaView, 'layout', {
-            nativeEvent: {
-                layout: {
-                    width: 200,
-                    height: 400,
-                },
-            },
-        });
+        fireSettledBoardLayout(safeAreaView, 200, 400);
 
         // Should initially have certain dimensions (1x2 grid: width=200/1=200, height=400/2=200)
         expect(getAllByText('Width: 200')).toHaveLength(2);
 
         // Change layout dimensions
-        fireEvent(safeAreaView, 'layout', {
-            nativeEvent: {
-                layout: {
-                    width: 400,
-                    height: 200,
-                },
-            },
-        });
+        fireBoardLayout(safeAreaView, 400, 200);
 
         // Should recalculate and update dimensions (2x1 grid: width=400/2=200, height=200/1=200)
         expect(getAllByText('Width: 200')).toHaveLength(2);
+    });
+
+    describe('layout helpers', () => {
+        it('calculates a square grid and dimensions for four players', () => {
+            const layout = calculateTileBoardLayout(4, 400, 600);
+
+            expect(layout).toEqual({
+                cols: 2,
+                height: 600,
+                rows: 2,
+                width: 400,
+            });
+            expect(calculateTileDimensions(layout)).toEqual({
+                height: 300,
+                width: 200,
+            });
+        });
+
+        it('keeps a two-player board balanced for portrait and landscape layouts', () => {
+            const portraitLayout = calculateTileBoardLayout(2, 200, 400);
+            const landscapeLayout = calculateTileBoardLayout(2, 400, 200);
+
+            expect(portraitLayout).toEqual({
+                cols: 1,
+                height: 400,
+                rows: 2,
+                width: 200,
+            });
+            expect(landscapeLayout).toEqual({
+                cols: 2,
+                height: 200,
+                rows: 1,
+                width: 400,
+            });
+        });
     });
 });

--- a/src/components/Boards/TileBoard.tsx
+++ b/src/components/Boards/TileBoard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo, useState } from 'react';
 
 import { LayoutChangeEvent, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -20,70 +20,27 @@ const TileBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
 
     if (playerIds == null || playerIds.length == 0) return null;
 
-    const [rows, setRows] = useState<number>(0);
-    const [cols, setCols] = useState<number>(0);
-
-    const [width, setWidth] = useState<number | null>(null);
-    const [height, setHeight] = useState<number | null>(null);
-
     const playerCount = playerIds.length;
-
-    const desiredAspectRatio = 1;
+    const [layoutState, setLayoutState] = useState<TileBoardLayoutState>({
+        layout: null,
+        measurementCount: 0,
+    });
 
     const layoutHandler = (e: LayoutChangeEvent) => {
         const { width, height } = e.nativeEvent.layout;
+        const layout = calculateTileBoardLayout(playerCount, Math.round(width), Math.round(height));
 
-        setWidth(Math.round(width));
-        setHeight(Math.round(height));
-        calcGrid();
-    };
-    const calcGrid = () => {
-        let closestAspectRatio = Number.MAX_SAFE_INTEGER;
-        let bestRowCount = 1;
-
-        if (width == null || height == null) return;
-
-        for (let rows = 1; rows <= playerIds.length; rows++) {
-            const cols = Math.ceil(playerIds.length / rows);
-
-            if (playerIds.length % rows > 0 && rows - playerIds.length % rows > 1) {
-                continue;
-            }
-
-            const w = width / cols;
-            const h = height / rows;
-            const ratio = w / h;
-
-            if (Math.abs(desiredAspectRatio - ratio) < Math.abs(desiredAspectRatio - closestAspectRatio)) {
-                closestAspectRatio = ratio;
-                bestRowCount = rows;
-            }
-        }
-
-        setRows(bestRowCount);
-        setCols(Math.ceil(playerIds.length / bestRowCount));
+        setLayoutState((previous) => ({
+            layout,
+            measurementCount: previous.measurementCount + 1,
+        }));
     };
 
-    useEffect(() => {
-        if (width == null || height == null) return;
-        calcGrid();
-    }, [playerCount, width, height]);
-
-    type DimensionValue = (rows: number, cols: number) => {
-        width: number;
-        height: number;
-    };
-
-    const calculateTileDimensions: DimensionValue = (rows: number, cols: number) => {
-        if (width == null || height == null) return { width: 0, height: 0 };
-
-        const dims = {
-            width: Math.round(width / cols),
-            height: Math.round(height / rows)
-        };
-
-        return dims;
-    };
+    const { layout, measurementCount } = layoutState;
+    const layoutReady = measurementCount > 1;
+    const tileDimensions = layout == null
+        ? null
+        : calculateTileDimensions(layout);
 
     return (
         <SafeAreaView edges={['left', 'right']} style={
@@ -94,20 +51,70 @@ const TileBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
             }]
         } onLayout={layoutHandler} >
             {playerIds.map((id, index) => (
-                width != null && height != null && rows != 0 && cols != 0 &&
+                layoutReady && layout != null && tileDimensions != null &&
                 <PlayerTile
                     key={id}
                     playerId={id}
-                    cols={cols}
-                    rows={rows}
-                    width={calculateTileDimensions(rows, cols).width}
-                    height={calculateTileDimensions(rows, cols).height}
+                    cols={layout.cols}
+                    rows={layout.rows}
+                    width={tileDimensions.width}
+                    height={tileDimensions.height}
                     index={index}
                     showHint={showHint}
                 />
             ))}
         </SafeAreaView>
     );
+};
+
+interface TileBoardLayout {
+    cols: number;
+    height: number;
+    rows: number;
+    width: number;
+}
+
+interface TileBoardLayoutState {
+    layout: TileBoardLayout | null;
+    measurementCount: number;
+}
+
+const desiredAspectRatio = 1;
+
+export const calculateTileBoardLayout = (playerCount: number, width: number, height: number): TileBoardLayout => {
+    let closestAspectRatio = Number.MAX_SAFE_INTEGER;
+    let bestRowCount = 1;
+
+    for (let rows = 1; rows <= playerCount; rows++) {
+        const cols = Math.ceil(playerCount / rows);
+
+        if (playerCount % rows > 0 && rows - playerCount % rows > 1) {
+            continue;
+        }
+
+        const w = width / cols;
+        const h = height / rows;
+        const ratio = w / h;
+
+        if (Math.abs(desiredAspectRatio - ratio) < Math.abs(desiredAspectRatio - closestAspectRatio)) {
+            closestAspectRatio = ratio;
+            bestRowCount = rows;
+        }
+    }
+
+    return {
+        cols: Math.ceil(playerCount / bestRowCount),
+        height,
+        rows: bestRowCount,
+        width,
+    };
+};
+
+export const calculateTileDimensions = (layout: TileBoardLayout) => {
+    return {
+        height: Math.round(layout.height / layout.rows),
+        width: Math.round(layout.width / layout.cols),
+    };
 };
 
 const styles = StyleSheet.create({

--- a/src/components/PlayerTiles/AdditionTile/Helpers.ts
+++ b/src/components/PlayerTiles/AdditionTile/Helpers.ts
@@ -1,14 +1,9 @@
-import { ZoomIn, withTiming } from 'react-native-reanimated';
+import { withTiming } from 'react-native-reanimated';
 
 /**
  * The duration of the animation in milliseconds.
  */
 export const animationDuration = 200;
-
-/**
- * The duration of the entering animation in milliseconds.
- */
-export const enteringAnimation = ZoomIn.duration(animationDuration);
 
 export const singleLineScoreSizeMultiplier = 1.2;
 

--- a/src/components/PlayerTiles/AdditionTile/ScoreAfter.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreAfter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import Animated, {
     useSharedValue,
@@ -6,7 +6,7 @@ import Animated, {
     withTiming
 } from 'react-native-reanimated';
 
-import { calculateFontSize, animationDuration, enteringAnimation, ZoomOutFadeOut } from './Helpers';
+import { calculateFontSize, animationDuration, ZoomOutFadeOut } from './Helpers';
 import { scoreStyles } from './scoreStyles';
 
 interface Props {
@@ -17,8 +17,9 @@ interface Props {
 }
 
 const ScoreAfter: React.FunctionComponent<Props> = ({ containerWidth, currentRoundScore, currentRoundTotalScore, fontColor }) => {
-    const fontSize = useSharedValue(calculateFontSize(containerWidth));
-    const opacity = useSharedValue(1);
+    const initialRender = useRef(true);
+    const fontSize = useSharedValue(currentRoundScore == 0 ? 1 : calculateFontSize(containerWidth) * 1.1);
+    const opacity = useSharedValue(currentRoundScore == 0 ? 0 : 1);
 
     const animatedStyles = useAnimatedStyle(() => {
         return {
@@ -28,6 +29,11 @@ const ScoreAfter: React.FunctionComponent<Props> = ({ containerWidth, currentRou
     });
 
     useEffect(() => {
+        if (initialRender.current) {
+            initialRender.current = false;
+            return;
+        }
+
         fontSize.value = withTiming(
             currentRoundScore == 0 ? 1 : calculateFontSize(containerWidth) * 1.1,
             { duration: animationDuration },
@@ -39,7 +45,7 @@ const ScoreAfter: React.FunctionComponent<Props> = ({ containerWidth, currentRou
     }, [currentRoundScore, containerWidth]);
 
     return (
-        <Animated.View entering={enteringAnimation} exiting={ZoomOutFadeOut}>
+        <Animated.View exiting={ZoomOutFadeOut}>
             <Animated.Text
                 allowFontScaling={false}
                 style={[animatedStyles, scoreStyles.scoreText, { color: fontColor }]}>

--- a/src/components/PlayerTiles/AdditionTile/ScoreAnimations.test.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreAnimations.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { render } from '@testing-library/react-native';
+import { withTiming } from 'react-native-reanimated';
+
+import ScoreAfter from './ScoreAfter';
+import ScoreBefore from './ScoreBefore';
+import ScoreRound from './ScoreRound';
+
+jest.mock('react-native-reanimated', () => {
+    const { Text, View } = jest.requireActual('react-native');
+
+    return {
+        __esModule: true,
+        default: {
+            Text,
+            View,
+        },
+        useAnimatedStyle: jest.fn((callback) => callback()),
+        useSharedValue: jest.fn((value) => ({ value })),
+        withTiming: jest.fn((value) => value),
+    };
+});
+
+const mockedWithTiming = withTiming as jest.Mock;
+
+describe('AdditionTile score animations', () => {
+    beforeEach(() => {
+        mockedWithTiming.mockClear();
+    });
+
+    it('renders initial zero scores without timing animations', () => {
+        render(
+            <>
+                <ScoreBefore containerWidth={200} currentRoundScore={0} currentRoundTotalScore={10} fontColor="#fff" />
+                <ScoreRound containerWidth={200} currentRoundScore={0} fontColor="#fff" />
+                <ScoreAfter containerWidth={200} currentRoundScore={0} currentRoundTotalScore={10} fontColor="#fff" />
+            </>
+        );
+
+        expect(mockedWithTiming).not.toHaveBeenCalled();
+    });
+
+    it('animates score values after the initial render', () => {
+        const { rerender } = render(
+            <>
+                <ScoreBefore containerWidth={200} currentRoundScore={0} currentRoundTotalScore={10} fontColor="#fff" />
+                <ScoreRound containerWidth={200} currentRoundScore={0} fontColor="#fff" />
+                <ScoreAfter containerWidth={200} currentRoundScore={0} currentRoundTotalScore={10} fontColor="#fff" />
+            </>
+        );
+
+        mockedWithTiming.mockClear();
+
+        rerender(
+            <>
+                <ScoreBefore containerWidth={200} currentRoundScore={5} currentRoundTotalScore={15} fontColor="#fff" />
+                <ScoreRound containerWidth={200} currentRoundScore={5} fontColor="#fff" />
+                <ScoreAfter containerWidth={200} currentRoundScore={5} currentRoundTotalScore={15} fontColor="#fff" />
+            </>
+        );
+
+        expect(mockedWithTiming).toHaveBeenCalled();
+    });
+});

--- a/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreBefore.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import Animated, {
     useSharedValue,
@@ -6,7 +6,7 @@ import Animated, {
     withTiming
 } from 'react-native-reanimated';
 
-import { calculateFontSize, animationDuration, enteringAnimation, multiLineScoreSizeMultiplier, singleLineScoreSizeMultiplier, scoreMathOpacity } from './Helpers';
+import { calculateFontSize, animationDuration, multiLineScoreSizeMultiplier, singleLineScoreSizeMultiplier, scoreMathOpacity } from './Helpers';
 
 interface Props {
     currentRoundScore: number;
@@ -21,10 +21,12 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
     currentRoundTotalScore,
     fontColor
 }) => {
+    const initialRender = useRef(true);
     const scoreBefore = currentRoundTotalScore - currentRoundScore;
+    const scaleFactor = currentRoundScore == 0 ? singleLineScoreSizeMultiplier : multiLineScoreSizeMultiplier;
 
-    const fontSize = useSharedValue(calculateFontSize(containerWidth));
-    const fontOpacity = useSharedValue(100);
+    const fontSize = useSharedValue(calculateFontSize(containerWidth) * scaleFactor);
+    const fontOpacity = useSharedValue(currentRoundScore == 0 ? 100 : scoreMathOpacity * 100);
 
     const animatedStyles = useAnimatedStyle(() => {
         return {
@@ -34,9 +36,12 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
         };
     });
 
-    const scaleFactor = currentRoundScore == 0 ? singleLineScoreSizeMultiplier : multiLineScoreSizeMultiplier;
-
     useEffect(() => {
+        if (initialRender.current) {
+            initialRender.current = false;
+            return;
+        }
+
         fontSize.value = withTiming(
             calculateFontSize(containerWidth) * scaleFactor,
             { duration: animationDuration }
@@ -49,7 +54,7 @@ const ScoreBefore: React.FunctionComponent<Props> = ({
     }, [currentRoundScore, containerWidth]);
 
     return (
-        <Animated.View entering={enteringAnimation}>
+        <Animated.View>
             <Animated.Text
                 allowFontScaling={false}
                 numberOfLines={1}

--- a/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
+++ b/src/components/PlayerTiles/AdditionTile/ScoreRound.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import Animated, {
     useSharedValue,
@@ -15,7 +15,8 @@ interface Props {
 }
 
 const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, currentRoundScore, fontColor }) => {
-    const fontSize = useSharedValue(calculateFontSize(containerWidth));
+    const initialRender = useRef(true);
+    const fontSize = useSharedValue(calculateFontSize(containerWidth) * multiLineScoreSizeMultiplier);
 
     const animatedStyles = useAnimatedStyle(() => {
         return {
@@ -26,6 +27,11 @@ const ScoreRound: React.FunctionComponent<Props> = ({ containerWidth, currentRou
     const d = currentRoundScore;
 
     useEffect(() => {
+        if (initialRender.current) {
+            initialRender.current = false;
+            return;
+        }
+
         fontSize.value = withTiming(
             calculateFontSize(containerWidth) * multiLineScoreSizeMultiplier,
             { duration: animationDuration }

--- a/src/screens/GameScreen.test.tsx
+++ b/src/screens/GameScreen.test.tsx
@@ -10,8 +10,10 @@ import settingsReducer from '../../redux/SettingsSlice';
 
 import GameScreen from './GameScreen';
 
+let mockHeaderHeight = 88;
+
 jest.mock('@react-navigation/elements', () => ({
-    useHeaderHeight: () => 88,
+    useHeaderHeight: () => mockHeaderHeight,
 }));
 
 jest.mock('react-native-reanimated', () => {
@@ -99,6 +101,10 @@ const createMockStore = (initialState: Parameters<typeof configureStore>[0]['pre
 };
 
 describe('GameScreen', () => {
+    beforeEach(() => {
+        mockHeaderHeight = 88;
+    });
+
     const mockGame = {
         id: 'game-1',
         title: 'Test Game',
@@ -168,8 +174,8 @@ describe('GameScreen', () => {
             </Provider>
         );
 
-        expect(getByTestId('tile-board')).toBeTruthy();
         expect(getByTestId('point-values-sheet')).toBeTruthy();
+        expect(getByTestId('tile-board')).toBeTruthy();
     });
 
     it('should render ListBoard when interactionType is Dial', () => {
@@ -196,4 +202,30 @@ describe('GameScreen', () => {
 
         expect(getByTestId('list-board')).toBeTruthy();
     });
+
+    it('should use the measured transparent header inset', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: { 'game-1': mockGame },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: mockPlayers,
+                ids: ['player-1', 'player-2'],
+            },
+        });
+
+        const { getByTestId, queryByTestId } = render(
+            <Provider store={store}>
+                <GameScreen />
+            </Provider>
+        );
+
+        expect(getByTestId('game-screen').props.style.paddingTop).toBe(88);
+        expect(queryByTestId('point-values-sheet')).toBeTruthy();
+    });
+
 });

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -41,12 +41,18 @@ const GameScreen: React.FunctionComponent = () => {
         <View style={{ flex: 1, paddingTop: headerHeight }} testID="game-screen">
             <View style={{ flex: 1 }}>
                 {interactionType === InteractionType.Dial
-                    ? <Animated.View key="rows" entering={FadeIn.duration(220)} exiting={FadeOut.duration(180)} style={StyleSheet.absoluteFill}>
-                        <ListBoard showHint={showHint} />
-                    </Animated.View>
-                    : <Animated.View key="flex" entering={FadeIn.duration(220)} exiting={FadeOut.duration(180)} style={StyleSheet.absoluteFill}>
-                        <TileBoard showHint={showHint} />
-                    </Animated.View>
+                    ? (
+                        <Animated.View key="rows" entering={FadeIn.duration(220)} exiting={FadeOut.duration(180)}
+                            style={StyleSheet.absoluteFill} testID="game-board-container">
+                            <ListBoard showHint={showHint} />
+                        </Animated.View>
+                    )
+                    : (
+                        <Animated.View key="flex" entering={FadeIn.duration(220)} exiting={FadeOut.duration(180)}
+                            style={StyleSheet.absoluteFill} testID="game-board-container">
+                            <TileBoard showHint={showHint} />
+                        </Animated.View>
+                    )
                 }
 
                 <PointValuesSheet />


### PR DESCRIPTION
## Summary
- consolidate TileBoard layout calculation into a single layout model and reuse tile dimensions across rows
- skip rendering tiles from the first transient board layout measurement to avoid the visible high-position frame
- remove per-tile load fade animations and make initial score text render directly at its first-frame state
- add regression coverage for settled TileBoard layout and initial score animation behavior

## Notes
- This intentionally avoids the earlier transition-level gating experiments; the final fix is scoped to TileBoard layout readiness so the game screen and GameSheet can load normally.

## Tests
- npm run test -- TileBoard --watchman=false --coverage=false
- npm run test -- AdditionTile --watchman=false --coverage=false
- npm run test -- GameScreen --watchman=false --coverage=false
- npm run test -- Navigation --watchman=false --coverage=false
- npm run lint