### PR TITLE
Add animated splash screen overlay with dark mode support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import analytics from '@react-native-firebase/analytics';
+import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
-import { View } from 'react-native';
+import { View, useColorScheme } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { MenuProvider } from 'react-native-popup-menu';
 import { configureReanimatedLogger, ReanimatedLogLevel } from 'react-native-reanimated';
@@ -18,15 +19,25 @@ import { persistor, store } from './redux/store';
 import { ChooseWinnersSheetContextProvider } from './src/components/Sheets/ChooseWinnersSheetContext';
 import { GameSheetContextProvider } from './src/components/Sheets/GameSheetContext';
 import { PointValuesSheetContextProvider } from './src/components/Sheets/PointValuesSheetContext';
+import { SplashOverlay } from './src/components/SplashOverlay';
 import { Navigation } from './src/Navigation';
+
+// Keep the native splash screen up until our animated SplashOverlay mounts and
+// calls hideAsync(). Without this, Expo auto-hides the native splash on first JS
+// frame — before the UI/persisted state is ready — causing the black flash.
+SplashScreen.preventAutoHideAsync();
 
 if (process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS == 'false') {
     analytics().setAnalyticsCollectionEnabled(false);
 }
 
 export default function App() {
+    const colorScheme = useColorScheme();
+    const bgColor = colorScheme === 'dark' ? '#000000' : '#F2F2F7';
+    const [splashDone, setSplashDone] = useState(false);
+
     return (
-        <View style={{ flex: 1, backgroundColor: '#000' }}>
+        <View style={{ flex: 1, backgroundColor: bgColor }}>
             <SafeAreaProvider>
                 <GestureHandlerRootView style={{ flex: 1 }}>
                     <Provider store={store}>
@@ -45,6 +56,7 @@ export default function App() {
                     </Provider>
                 </GestureHandlerRootView>
             </SafeAreaProvider>
+            {!splashDone && <SplashOverlay onDone={() => setSplashDone(true)} />}
         </View>
     );
 };

--- a/app.config.js
+++ b/app.config.js
@@ -76,7 +76,7 @@ export default {
   orientation: 'default',
   icon: icon,
   assetBundlePatterns: ['assets/*'],
-  backgroundColor: '#000000',
+  backgroundColor: '#F2F2F7',
   ios: {
     bundleIdentifier: packageName,
     supportsTablet: true,
@@ -120,6 +120,10 @@ export default {
   githubUrl: 'https://github.com/wyne/scorepad-react-native',
   owner: 'wyne',
   plugins: [
+    ['expo-splash-screen', {
+      backgroundColor: '#F2F2F7',
+      dark: { backgroundColor: '#000000' },
+    }],
     './plugins/withTouchVisualizer',
     'expo-font',
     '@react-native-firebase/app',

--- a/src/components/SplashOverlay.tsx
+++ b/src/components/SplashOverlay.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect } from 'react';
+
+import { Image } from 'expo-image';
+import * as SplashScreen from 'expo-splash-screen';
+import { StyleSheet, useColorScheme } from 'react-native';
+import Animated, {
+    Easing,
+    runOnJS,
+    useAnimatedStyle,
+    useSharedValue,
+    withDelay,
+    withSequence,
+    withTiming,
+} from 'react-native-reanimated';
+
+import icon from '../../assets/icon.png';
+
+interface Props {
+    onDone: () => void;
+}
+
+export const SplashOverlay: React.FC<Props> = ({ onDone }) => {
+    const colorScheme = useColorScheme();
+    const bgColor = colorScheme === 'dark' ? '#000000' : '#F2F2F7';
+
+    const overlayOpacity = useSharedValue(1);
+    const iconOpacity = useSharedValue(0);
+    const iconScale = useSharedValue(0.92);
+
+    const runDone = useCallback(() => onDone(), [onDone]);
+
+    useEffect(() => {
+        SplashScreen.hideAsync();
+
+        iconOpacity.value = withTiming(1, { duration: 350 });
+
+        overlayOpacity.value = withDelay(
+            700,
+            withTiming(0, { duration: 350, easing: Easing.in(Easing.quad) }, (finished) => {
+                if (finished) runOnJS(runDone)();
+            })
+        );
+        iconScale.value = withSequence(
+            withTiming(1, { duration: 450, easing: Easing.out(Easing.cubic) }),
+            withDelay(250, withTiming(1.04, { duration: 350, easing: Easing.in(Easing.quad) }))
+        );
+    }, []);
+
+    const overlayStyle = useAnimatedStyle(() => ({
+        opacity: overlayOpacity.value,
+    }));
+
+    const iconStyle = useAnimatedStyle(() => ({
+        opacity: iconOpacity.value,
+        transform: [{ scale: iconScale.value }],
+    }));
+
+    return (
+        <Animated.View
+            style={[styles.container, { backgroundColor: bgColor }, overlayStyle]}
+            pointerEvents="none"
+        >
+            <Animated.View style={iconStyle}>
+                <Image
+                    source={icon}
+                    contentFit="contain"
+                    style={styles.icon}
+                />
+            </Animated.View>
+        </Animated.View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        ...StyleSheet.absoluteFill,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    icon: {
+        width: 110,
+        height: 110,
+        borderRadius: 24,
+    },
+});


### PR DESCRIPTION
## Summary
Implemented a custom animated splash screen overlay that displays the app icon with smooth fade-in and scale animations before transitioning to the main app. The overlay respects the device's color scheme preference (light/dark mode).

## Key Changes
- **New SplashOverlay component** (`src/components/SplashOverlay.tsx`): 
  - Displays app icon with entrance animation (fade-in + scale-up)
  - Implements exit animation (scale-up + fade-out) after 700ms delay
  - Uses React Native Reanimated for smooth 60fps animations
  - Supports light and dark mode backgrounds
  
- **Updated App.tsx**:
  - Added state management for splash screen completion
  - Integrated SplashOverlay component with conditional rendering
  - Updated background color to respect system color scheme
  - Called `SplashScreen.preventAutoHideAsync()` to manage splash timing
  
- **Updated app.config.js**:
  - Changed default background color from black to light gray (`#F2F2F7`)
  - Added expo-splash-screen plugin configuration with light/dark mode support

## Implementation Details
- The splash overlay uses `expo-splash-screen` to hide the native splash screen and manage timing
- Animation sequence: icon fades in (350ms) and scales from 0.92 to 1.0 (450ms), then after 700ms delay the overlay fades out (350ms) while icon scales to 1.04
- The overlay is positioned absolutely and uses `pointerEvents="none"` to avoid blocking interactions
- Color scheme detection uses React Native's `useColorScheme()` hook for automatic light/dark mode support

https://claude.ai/code/session_0175vJz9kjKtayGEcEig7fX6