### PR TITLE
Improve install-ipa.sh: relative time, column alignment, fzf display

### DIFF
--- a/scripts/install-ipa.sh
+++ b/scripts/install-ipa.sh
@@ -60,13 +60,14 @@ if command -v fzf &>/dev/null; then
         for f in "${IPAS[@]}"; do
             name=$(basename "$f")
             IFS='|' read -r ver ts rel <<< "$(ipa_info "$f" "$name")"
-            printf "%s|%s|%s|%s|%s\n" "$rel" "$name" "$ver" "$ts" "$f"
+            rel_disp="${rel:-unknown}"
+            printf "%s|%s|%s|%s|%s\n" "$rel_disp" "$name" "$ver" "$ts" "$f"
         done | fzf \
             --prompt='> ' \
             --with-nth='1..4' \
             --delimiter='|' \
             --preview "
-                f=\$(echo {} | cut -d'|' -f4)
+                f=\$(echo {} | cut -d'|' -f5)
                 unzip -p \"\$f\" 'Payload/*.app/Info.plist' 2>/dev/null | plutil -convert json -o - - 2>/dev/null | python3 -c \"
 import sys, json
 d = json.load(sys.stdin)
@@ -86,7 +87,7 @@ else
     for i in "${!IPAS[@]}"; do
         name=$(basename "${IPAS[$i]}")
         IFS='|' read -r ver ts rel <<< "$(ipa_info "${IPAS[$i]}" "$name")"
-        echo -e "  $((i+1)). ${COLOR_DIM}${rel}${COLOR_RESET}  ${COLOR_CYAN}${name}${COLOR_RESET}  ${COLOR_YELLOW}${ver}${COLOR_RESET}  ${COLOR_DIM}${ts}${COLOR_RESET}"
+        echo -e "  $((i+1)). ${COLOR_YELLOW}${rel:-unknown}${COLOR_RESET}  ${COLOR_CYAN}${name}${COLOR_RESET}  ${COLOR_DIM}${ver}${COLOR_RESET}  ${COLOR_DIM}${ts}${COLOR_RESET}"
     done
     printf "Select IPA [1-%d]: " "${#IPAS[@]}"
     read -r n; n=$((n - 1))

--- a/scripts/install-ipa.sh
+++ b/scripts/install-ipa.sh
@@ -23,10 +23,15 @@ relative_time() {
 
 ipa_info() {
     local f=$1 name=$2
-    local ver="" ts="" rel=""
+    local ver="" ts="" rel="" e=""
     if [[ "$name" =~ ^build-([0-9]+)\.ipa$ ]]; then
-        local e=$((BASH_REMATCH[1] / 1000))
-        ts=$(date -r "$e" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown")
+        e=$((BASH_REMATCH[1] / 1000))
+    else
+        # Fall back to the file's modification time for arbitrarily named IPAs
+        e=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo "")
+    fi
+    if [ -n "$e" ]; then
+        ts=$(date -r "$e" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "")
         rel=$(relative_time "$e")
     fi
     if plist=$(unzip -p "$f" "Payload/*.app/Info.plist" 2>/dev/null); then
@@ -61,13 +66,13 @@ if command -v fzf &>/dev/null; then
             name=$(basename "$f")
             IFS='|' read -r ver ts rel <<< "$(ipa_info "$f" "$name")"
             rel_disp="${rel:-unknown}"
-            printf "%s|%s|%s|%s|%s\n" "$rel_disp" "$name" "$ver" "$ts" "$f"
+            printf "%s  %s  %s  %s|%s\n" "$rel_disp" "$name" "$ver" "$ts" "$f"
         done | fzf \
             --prompt='> ' \
-            --with-nth='1..4' \
+            --with-nth='1' \
             --delimiter='|' \
             --preview "
-                f=\$(echo {} | cut -d'|' -f5)
+                f=\$(echo {} | cut -d'|' -f2)
                 unzip -p \"\$f\" 'Payload/*.app/Info.plist' 2>/dev/null | plutil -convert json -o - - 2>/dev/null | python3 -c \"
 import sys, json
 d = json.load(sys.stdin)
@@ -81,7 +86,7 @@ print('Min OS:', d.get('MinimumOSVersion', '?'))
             --height=~50% \
             2>/dev/null || true)
     if [ -z "$IPA_PATH" ]; then echo "Cancelled." >&2; exit 1; fi
-    IPA_PATH=$(echo "$IPA_PATH" | cut -d'|' -f5)
+    IPA_PATH=$(echo "$IPA_PATH" | cut -d'|' -f2)
 else
     echo -e "${COLOR_BOLD}Select an IPA:${COLOR_RESET}"
     for i in "${!IPAS[@]}"; do

--- a/scripts/install-ipa.sh
+++ b/scripts/install-ipa.sh
@@ -60,11 +60,10 @@ if command -v fzf &>/dev/null; then
         for f in "${IPAS[@]}"; do
             name=$(basename "$f")
             IFS='|' read -r ver ts rel <<< "$(ipa_info "$f" "$name")"
-            if [ -n "$rel" ]; then ts_disp="${ts} (${rel})"; else ts_disp="$ts"; fi
-            printf "%s|%s|%s|%s\n" "$name" "$ver" "$ts_disp" "$f"
+            printf "%s|%s|%s|%s|%s\n" "$rel" "$name" "$ver" "$ts" "$f"
         done | fzf \
             --prompt='> ' \
-            --with-nth='1..3' \
+            --with-nth='1..4' \
             --delimiter='|' \
             --preview "
                 f=\$(echo {} | cut -d'|' -f4)
@@ -81,14 +80,13 @@ print('Min OS:', d.get('MinimumOSVersion', '?'))
             --height=~50% \
             2>/dev/null || true)
     if [ -z "$IPA_PATH" ]; then echo "Cancelled." >&2; exit 1; fi
-    IPA_PATH=$(echo "$IPA_PATH" | cut -d'|' -f4)
+    IPA_PATH=$(echo "$IPA_PATH" | cut -d'|' -f5)
 else
     echo -e "${COLOR_BOLD}Select an IPA:${COLOR_RESET}"
     for i in "${!IPAS[@]}"; do
         name=$(basename "${IPAS[$i]}")
         IFS='|' read -r ver ts rel <<< "$(ipa_info "${IPAS[$i]}" "$name")"
-        ts_disp="${ts:+$ts (${rel:-$ts})}"
-        echo -e "  $((i+1)). ${COLOR_CYAN}${name}${COLOR_RESET}  ${COLOR_YELLOW}${ver}${COLOR_RESET}  ${COLOR_DIM}${ts_disp}${COLOR_RESET}"
+        echo -e "  $((i+1)). ${COLOR_DIM}${rel}${COLOR_RESET}  ${COLOR_CYAN}${name}${COLOR_RESET}  ${COLOR_YELLOW}${ver}${COLOR_RESET}  ${COLOR_DIM}${ts}${COLOR_RESET}"
     done
     printf "Select IPA [1-%d]: " "${#IPAS[@]}"
     read -r n; n=$((n - 1))

--- a/scripts/install-ipa.sh
+++ b/scripts/install-ipa.sh
@@ -61,12 +61,25 @@ fi
 
 if command -v fzf &>/dev/null; then
     echo "Select an IPA:"
+    # First pass: gather rows and compute column widths so they align.
+    rels=(); names=(); vers=(); tss=(); paths=()
+    w_rel=0; w_name=0; w_ver=0
+    for f in "${IPAS[@]}"; do
+        name=$(basename "$f")
+        IFS='|' read -r ver ts rel <<< "$(ipa_info "$f" "$name")"
+        rel="${rel:-unknown}"
+        rels+=("$rel"); names+=("$name"); vers+=("$ver"); tss+=("$ts"); paths+=("$f")
+        (( ${#rel}  > w_rel ))  && w_rel=${#rel}
+        (( ${#name} > w_name )) && w_name=${#name}
+        (( ${#ver}  > w_ver ))  && w_ver=${#ver}
+    done
     IPA_PATH=$(
-        for f in "${IPAS[@]}"; do
-            name=$(basename "$f")
-            IFS='|' read -r ver ts rel <<< "$(ipa_info "$f" "$name")"
-            rel_disp="${rel:-unknown}"
-            printf "%s  %s  %s  %s|%s\n" "$rel_disp" "$name" "$ver" "$ts" "$f"
+        for i in "${!paths[@]}"; do
+            printf "%-*s  %-*s  %-*s  %s|%s\n" \
+                "$w_rel" "${rels[$i]}" \
+                "$w_name" "${names[$i]}" \
+                "$w_ver" "${vers[$i]}" \
+                "${tss[$i]}" "${paths[$i]}"
         done | fzf \
             --prompt='> ' \
             --with-nth='1' \


### PR DESCRIPTION
## Summary

- Move relative time (e.g. "just now", "3m ago") to the front of each IPA entry so the most useful context appears first
- Fall back to file mtime (via `stat`) when the filename doesn't match the `build-<timestamp>.ipa` pattern, so preview/production IPAs show a meaningful time instead of "unknown"
- Fix fzf display: drop `|` pipe separators from visible columns; use a single `|` only as an internal delimiter before the path for `cut -d'|' -f2` extraction
- Two-pass column alignment: first pass computes max widths for relative-time, filename, and version columns; second pass uses `printf "%-*s"` so all entries line up cleanly

## Test plan

- [x] Run `scripts/install-ipa.sh` with multiple `.ipa` files in the project root (mix of `build-<timestamp>.ipa` and arbitrarily named files)
- [x] Confirm relative time appears at the front of each row and is not "unknown"
- [x] Confirm columns are aligned when there are entries of varying lengths
- [x] Confirm fzf selection works and the correct IPA path is extracted

---
_Generated by [Claude Code](https://claude.ai/code/session_0175vJz9kjKtayGEcEig7fX6)_