### PR TITLE
Improve edit input replacement UX

### DIFF
--- a/redux/PlayersSlice.test.ts
+++ b/redux/PlayersSlice.test.ts
@@ -4,6 +4,7 @@ import playersReducer, {
     playerAdd,
     playerRoundScoreIncrement,
     playerRoundScoreSet,
+    selectAllPlayerNames,
     selectAllPlayers,
     selectPlayerGrandTotalScore,
     selectPlayerRoundStats,
@@ -227,6 +228,32 @@ describe('player sort order', () => {
         const ordered = selectAllPlayers({ players }).map((p) => p.id);
         expect(ordered).toHaveLength(2);
         expect(ordered).toEqual(expect.arrayContaining(['a', 'b']));
+    });
+});
+
+describe('selectAllPlayerNames', () => {
+    it('should return unique player names with a stable memoized reference', () => {
+        const players = playersReducer(undefined, playerAdd({
+            id: '1',
+            playerName: 'Alice',
+            scores: [],
+        }));
+        const withDuplicateName = playersReducer(players, playerAdd({
+            id: '2',
+            playerName: 'Alice',
+            scores: [],
+        }));
+        const withOtherName = playersReducer(withDuplicateName, playerAdd({
+            id: '3',
+            playerName: 'Bob',
+            scores: [],
+        }));
+        const state = { players: withOtherName } as RootState;
+
+        const result = selectAllPlayerNames(state);
+
+        expect(result).toEqual(['Alice', 'Bob']);
+        expect(selectAllPlayerNames(state)).toBe(result);
     });
 });
 

--- a/redux/PlayersSlice.ts
+++ b/redux/PlayersSlice.ts
@@ -105,6 +105,17 @@ export const selectPlayerNameById = createSelector(
     (player) => player?.playerName
 );
 
+export const selectAllPlayerNames = createSelector(
+    [(state: RootState) => state.players.entities],
+    (entities) => {
+        const names: string[] = [];
+        for (const player of Object.values(entities)) {
+            if (player) names.push(player.playerName);
+        }
+        return [...new Set(names)];
+    }
+);
+
 export const selectPlayerScoreByRound = createSelector(
     [
         (state: RootState) => state.players.entities,

--- a/src/components/EditGame.test.tsx
+++ b/src/components/EditGame.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
 import { fireEvent, render } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import { Provider } from 'react-redux';
 
 import gamesReducer from '../../redux/GamesSlice';
@@ -11,28 +12,45 @@ import settingsReducer from '../../redux/SettingsSlice';
 import EditGame from './EditGame';
 
 // Mock react-native-elements
-jest.mock('react-native-elements', () => ({
-    Input: ({ defaultValue, onChangeText, onEndEditing, onBlur, placeholder, testID }: {
-        defaultValue: string;
-        onChangeText: (text: string) => void;
-        onEndEditing: (e: { nativeEvent: { text: string } }) => void;
-        onBlur: (e: { nativeEvent: { text: string } }) => void;
-        placeholder: string;
-        testID?: string;
-    }) => {
-        const { TextInput } = jest.requireActual('react-native');
-        return (
-            <TextInput
-                defaultValue={defaultValue}
-                onChangeText={onChangeText}
-                onEndEditing={(e: { nativeEvent: { text: string } }) => onEndEditing({ nativeEvent: { text: e.nativeEvent.text } })}
-                onBlur={(e: { nativeEvent: { text: string } }) => onBlur({ nativeEvent: { text: e.nativeEvent.text } })}
-                placeholder={placeholder}
-                testID={testID || 'game-title-input'}
-            />
-        );
-    },
-}));
+jest.mock('react-native-elements', () => {
+    const React = jest.requireActual('react');
+    const { Pressable, TextInput } = jest.requireActual('react-native');
+
+    return {
+        Input: React.forwardRef(({ value, onChangeText, onEndEditing, onSubmitEditing, onBlur, placeholder, testID, rightIcon, ...props }: {
+            value: string;
+            onChangeText: (text: string) => void;
+            onEndEditing: (e: { nativeEvent: { text: string } }) => void;
+            onSubmitEditing: (e: { nativeEvent: { text: string } }) => void;
+            onBlur: () => void;
+            placeholder: string;
+            rightIcon?: { onPress: () => void; name: string };
+            testID?: string;
+        }, ref: React.Ref<{ focus: () => void }>) => {
+            React.useImperativeHandle(ref, () => ({
+                focus: jest.fn(),
+            }));
+
+            return (
+                <>
+                    <TextInput
+                        onBlur={onBlur}
+                        onChangeText={onChangeText}
+                        onEndEditing={(e: { nativeEvent: { text: string } }) => onEndEditing({ nativeEvent: { text: e.nativeEvent.text } })}
+                        onSubmitEditing={(e: { nativeEvent: { text: string } }) => onSubmitEditing({ nativeEvent: { text: e.nativeEvent.text } })}
+                        placeholder={placeholder}
+                        testID={testID || 'game-title-input'}
+                        value={value}
+                        {...props}
+                    />
+                    {rightIcon != null && (
+                        <Pressable onPress={rightIcon.onPress} testID="game-title-clear-button" />
+                    )}
+                </>
+            );
+        }),
+    };
+});
 
 // Mock @react-navigation/native
 jest.mock('@react-navigation/native', () => ({
@@ -89,6 +107,10 @@ describe('EditGame', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        Object.defineProperty(Platform, 'OS', {
+            configurable: true,
+            value: 'ios',
+        });
     });
 
     it('should render null when no current game is set', () => {
@@ -427,7 +449,71 @@ describe('EditGame', () => {
         );
 
         const input = getByTestId('game-title-input');
-        expect(input.props.defaultValue).toBe('');
+        expect(input.props.value).toBe('');
+    });
+
+    it('should use native replacement affordances', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: mockPlayers,
+                ids: ['player-1', 'player-2'],
+            },
+        });
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <EditGame />
+            </Provider>
+        );
+
+        const input = getByTestId('game-title-input');
+
+        expect(input.props.clearButtonMode).toBe('while-editing');
+        expect(input.props.returnKeyType).toBe('done');
+        expect(input.props.selectTextOnFocus).toBe(true);
+    });
+
+    it('should clear the game title locally with the Android clear button', () => {
+        Object.defineProperty(Platform, 'OS', {
+            configurable: true,
+            value: 'android',
+        });
+
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: mockPlayers,
+                ids: ['player-1', 'player-2'],
+            },
+        });
+
+        const { getByDisplayValue, getByTestId } = render(
+            <Provider store={store}>
+                <EditGame />
+            </Provider>
+        );
+
+        fireEvent.press(getByTestId('game-title-clear-button'));
+
+        expect(getByDisplayValue('')).toBeTruthy();
+        expect(store.getState().games.entities['game-1']?.title).toBe('Test Game');
     });
 
     it('should handle very long titles within character limit', () => {

--- a/src/components/EditGame.tsx
+++ b/src/components/EditGame.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect, useState } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
-import { NativeSyntheticEvent, StyleSheet, Text, TextInputEndEditingEventData, View } from 'react-native';
+import {
+    NativeSyntheticEvent,
+    Platform,
+    StyleSheet,
+    Text,
+    TextInput,
+    TextInputEndEditingEventData,
+    TextInputSubmitEditingEventData,
+    View
+} from 'react-native';
 import { Input } from 'react-native-elements';
 
 import { updateGame } from '../../redux/GamesSlice';
@@ -18,6 +27,7 @@ const EditGame = ({ }) => {
     const dispatch = useAppDispatch();
     const currentGame = useAppSelector(selectCurrentGame);
     const [localTitle, setLocalTitle] = useState(currentGame?.title ?? '');
+    const inputRef = React.useRef<TextInput>(null);
 
     const navigation = useNavigation();
 
@@ -48,18 +58,30 @@ const EditGame = ({ }) => {
         commitTitle(text);
     };
 
+    const onSubmitEditingHandler = (e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => {
+        const text = e.nativeEvent.text;
+        commitTitle(text);
+    };
+
     const onChangeTextHandler = (text: string) => {
         setLocalTitle(text);
+    };
+
+    const clearTitle = () => {
+        setLocalTitle('');
+        inputRef.current?.focus();
     };
 
     return (
         <>
             <View style={[styles.inputContainer, { backgroundColor: theme.inputBackground }]}>
                 <Input
-                    defaultValue={localTitle}
+                    ref={inputRef}
+                    clearButtonMode="while-editing"
                     maxLength={30}
                     onChangeText={onChangeTextHandler}
                     onEndEditing={onEndEditingHandler}
+                    onSubmitEditing={onSubmitEditingHandler}
                     onBlur={() => {
                         if (localTitle == '') {
                             commitTitle(UNTITLED);
@@ -67,8 +89,20 @@ const EditGame = ({ }) => {
                     }}
                     placeholder={UNTITLED}
                     renderErrorMessage={false}
+                    returnKeyType="done"
+                    rightIcon={Platform.OS === 'ios' ? undefined : {
+                        style: { padding: 8 },
+                        disabled: localTitle == '',
+                        disabledStyle: { display: 'none' },
+                        color: theme.textTertiary,
+                        size: 15,
+                        name: 'close',
+                        onPress: clearTitle,
+                    }}
+                    selectTextOnFocus={true}
                     style={{ color: theme.inputText }}
                     inputContainerStyle={{ borderBottomWidth: 0 }}
+                    value={localTitle}
                 />
             </View>
             <View style={{ marginHorizontal: 20 }}>

--- a/src/components/FloatingActionButton.test.tsx
+++ b/src/components/FloatingActionButton.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { configureStore } from '@reduxjs/toolkit';
+import { act, render } from '@testing-library/react-native';
+import { Keyboard } from 'react-native';
+import { Provider } from 'react-redux';
+
+import gamesReducer from '../../redux/GamesSlice';
+import playersReducer from '../../redux/PlayersSlice';
+import settingsReducer, { initialState as initialSettingsState } from '../../redux/SettingsSlice';
+
+import FloatingActionButton from './FloatingActionButton';
+
+jest.mock('expo-crypto', () => ({
+    randomUUID: jest.fn(() => 'mock-uuid'),
+}));
+
+jest.mock('../Analytics', () => ({
+    logEvent: jest.fn(),
+}));
+
+jest.mock('../ColorPalette', () => ({
+    getPalette: jest.fn(() => ['#ffffff']),
+}));
+
+jest.mock('react-native-elements', () => ({
+    Icon: () => null,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+let capturedOnOpenMenu: (() => void) | undefined;
+let capturedOnPressAction: ((event: { nativeEvent: { event: string } }) => void) | undefined;
+
+jest.mock('@react-native-menu/menu', () => {
+    const { View } = jest.requireActual('react-native');
+
+    return {
+        MenuView: ({ children, onOpenMenu, onPressAction }: {
+            children: React.ReactNode;
+            onOpenMenu?: () => void;
+            onPressAction?: (event: { nativeEvent: { event: string } }) => void;
+        }) => {
+            capturedOnOpenMenu = onOpenMenu;
+            capturedOnPressAction = onPressAction;
+            return <View testID="player-count-menu">{children}</View>;
+        },
+    };
+});
+
+const createMockStore = () => configureStore({
+    reducer: {
+        settings: settingsReducer,
+        games: gamesReducer,
+        players: playersReducer,
+    },
+    preloadedState: {
+        settings: {
+            ...initialSettingsState,
+            currentGameId: undefined,
+        },
+        games: {
+            entities: {},
+            ids: [],
+        },
+        players: {
+            entities: {},
+            ids: [],
+        },
+    },
+});
+
+const mockNavigation = {
+    navigate: jest.fn(),
+} as unknown as NativeStackNavigationProp<ParamListBase, string, undefined>;
+
+describe('FloatingActionButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        capturedOnOpenMenu = undefined;
+        capturedOnPressAction = undefined;
+        jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => undefined);
+    });
+
+    it('dismisses the keyboard when the player count menu opens', () => {
+        render(
+            <Provider store={createMockStore()}>
+                <FloatingActionButton navigation={mockNavigation} />
+            </Provider>
+        );
+
+        capturedOnOpenMenu?.();
+
+        expect(Keyboard.dismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismisses the keyboard before creating a game from the menu', async () => {
+        render(
+            <Provider store={createMockStore()}>
+                <FloatingActionButton navigation={mockNavigation} />
+            </Provider>
+        );
+
+        await act(async () => {
+            capturedOnPressAction?.({ nativeEvent: { event: '2' } });
+        });
+
+        expect(Keyboard.dismiss).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { MenuAction, MenuView } from '@react-native-menu/menu';
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { StyleSheet, View } from 'react-native';
+import { Keyboard, StyleSheet, View } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -51,7 +51,11 @@ const FloatingActionButton: React.FunctionComponent<Props> = ({ navigation }) =>
         }]}>
             <MenuView
                 style={StyleSheet.absoluteFill}
+                onOpenMenu={() => {
+                    Keyboard.dismiss();
+                }}
                 onPressAction={async ({ nativeEvent }) => {
+                    Keyboard.dismiss();
                     const playerNumber = parseInt(nativeEvent.event);
                     addGameHandler(playerNumber);
                 }}

--- a/src/screens/EditPlayerScreen.test.tsx
+++ b/src/screens/EditPlayerScreen.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
-import { Platform } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 import { Provider } from 'react-redux';
 
 import gamesReducer from '../../redux/GamesSlice';
@@ -522,6 +522,50 @@ describe('EditPlayerScreen', () => {
 
         expect(getByDisplayValue('')).toBeTruthy();
         expect(store.getState().players.entities['player-1']?.playerName).toBe('Test Player');
+    });
+
+    it('should dismiss the keyboard before navigating back', async () => {
+        const dismissSpy = jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => undefined);
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: {
+                    'player-1': mockPlayer,
+                },
+                ids: ['player-1'],
+            },
+        });
+
+        const mockRoute = {
+            params: {
+                index: 0,
+                playerId: 'player-1',
+            },
+        };
+
+        render(
+            <Provider store={store}>
+                <EditPlayerScreen navigation={mockNavigation} route={mockRoute as any} />
+            </Provider>
+        );
+
+        const options = mockNavigation.setOptions.mock.calls[0][0];
+        const backButton = options.headerLeft({ tintColor: '#fff' });
+
+        await act(async () => {
+            await backButton.props.onPress();
+        });
+
+        expect(dismissSpy).toHaveBeenCalled();
+        expect(mockNavigation.goBack).toHaveBeenCalled();
     });
 
     it('should limit input to 15 characters', () => {

--- a/src/screens/EditPlayerScreen.test.tsx
+++ b/src/screens/EditPlayerScreen.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import { Provider } from 'react-redux';
 
 import gamesReducer from '../../redux/GamesSlice';
@@ -99,6 +100,10 @@ describe('EditPlayerScreen', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        Object.defineProperty(Platform, 'OS', {
+            configurable: true,
+            value: 'ios',
+        });
     });
 
     it('should render null when playerId is null', () => {
@@ -300,7 +305,7 @@ describe('EditPlayerScreen', () => {
         expect(state.players.entities['player-1']?.playerName).toBe('New Player Name');
     });
 
-    it('should revert to original name when input is empty on change', () => {
+    it('should allow empty local text without saving blank while editing', () => {
         const store = createMockStore({
             settings: {
                 currentGameId: 'game-1',
@@ -335,7 +340,9 @@ describe('EditPlayerScreen', () => {
         const input = getByDisplayValue('Test Player');
         fireEvent.changeText(input, '');
 
-        // Check that the store was updated with the original name
+        expect(getByDisplayValue('')).toBeTruthy();
+
+        // Empty text is only local while editing; Redux keeps the last valid name.
         const state = store.getState();
         expect(state.players.entities['player-1']?.playerName).toBe('Test Player');
     });
@@ -386,6 +393,47 @@ describe('EditPlayerScreen', () => {
         expect(state.players.entities['player-1']?.playerName).toBe('Test Player');
     });
 
+    it('should revert to original name when empty input blurs', () => {
+        const store = createMockStore({
+            settings: {
+                currentGameId: 'game-1',
+            },
+            games: {
+                entities: {
+                    'game-1': mockGame,
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: {
+                    'player-1': mockPlayer,
+                },
+                ids: ['player-1'],
+            },
+        });
+
+        const mockRoute = {
+            params: {
+                index: 0,
+                playerId: 'player-1',
+            },
+        };
+
+        const { getByDisplayValue } = render(
+            <Provider store={store}>
+                <EditPlayerScreen navigation={mockNavigation} route={mockRoute as any} />
+            </Provider>
+        );
+
+        const input = getByDisplayValue('Test Player');
+
+        fireEvent.changeText(input, '');
+        fireEvent(input, 'blur');
+
+        expect(getByDisplayValue('Test Player')).toBeTruthy();
+        expect(store.getState().players.entities['player-1']?.playerName).toBe('Test Player');
+    });
+
     it('should save new name when input has text on end editing', () => {
         const store = createMockStore({
             settings: {
@@ -427,6 +475,11 @@ describe('EditPlayerScreen', () => {
     });
 
     it('should clear input when clear button is pressed', () => {
+        Object.defineProperty(Platform, 'OS', {
+            configurable: true,
+            value: 'android',
+        });
+
         const store = createMockStore({
             settings: {
                 currentGameId: 'game-1',
@@ -452,15 +505,23 @@ describe('EditPlayerScreen', () => {
             },
         };
 
-        const { getByTestId } = render(
+        const { getByDisplayValue, getByTestId } = render(
             <Provider store={store}>
                 <EditPlayerScreen navigation={mockNavigation} route={mockRoute as any} />
             </Provider>
         );
 
-        // Should render the input field successfully
         const input = getByTestId('RNE__Input__text-input');
-        expect(input).toBeTruthy();
+        const clearButton = input.parent?.parent?.findByProps({ name: 'close' });
+
+        if (clearButton == null) {
+            throw new Error('Expected Android clear button to render');
+        }
+
+        fireEvent.press(clearButton);
+
+        expect(getByDisplayValue('')).toBeTruthy();
+        expect(store.getState().players.entities['player-1']?.playerName).toBe('Test Player');
     });
 
     it('should limit input to 15 characters', () => {
@@ -597,7 +658,7 @@ describe('EditPlayerScreen', () => {
         expect(getByDisplayValue('')).toBeTruthy();
     });
 
-    it('should hide clear button when input is empty', () => {
+    it('should use the native iOS clear button mode', () => {
         const playerWithEmptyName = {
             id: 'player-2',
             playerName: '',
@@ -636,10 +697,9 @@ describe('EditPlayerScreen', () => {
         );
 
         const input = getByDisplayValue('');
-        
-        // The clear button should be disabled and hidden when input is empty
-        const clearButton = input.parent?.parent?.findByProps({ name: 'close' });
-        expect(clearButton?.props.disabled).toBe(true);
+
+        expect(input.props.clearButtonMode).toBe('while-editing');
+        expect(input.props.returnKeyType).toBe('done');
     });
 
     describe('suggestion feature', () => {

--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -17,7 +17,7 @@ import {
 import { Input } from 'react-native-elements';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { updatePlayer } from '../../redux/PlayersSlice';
+import { selectAllPlayerNames, updatePlayer } from '../../redux/PlayersSlice';
 import { selectCurrentGame } from '../../redux/selectors';
 import { logEvent } from '../Analytics';
 import HeaderButton from '../components/Buttons/HeaderButton';
@@ -70,13 +70,7 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     const [localPlayerName, setLocalPlayerName] = useState<string>(player?.playerName || '');
     const [isFocused, setIsFocused] = useState(false);
 
-    const allPlayerNames = useAppSelector(state => {
-        const names: string[] = [];
-        for (const p of Object.values(state.players.entities)) {
-            if (p) names.push(p.playerName);
-        }
-        return [...new Set(names)];
-    });
+    const allPlayerNames = useAppSelector(selectAllPlayerNames);
 
     const suggestions = useMemo(() => {
         if (!isFocused || localPlayerName.length === 0) return [];

--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -1,9 +1,10 @@
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { ParamListBase, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
     NativeSyntheticEvent,
+    Keyboard,
     Platform,
     ScrollView,
     StyleSheet,
@@ -42,11 +43,19 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
 }) => {
 
     const theme = useTheme();
+    const inputRef = React.useRef<TextInput>(null);
+    const selectedNameRef = useRef<string | null>(null);
+
+    const dismissInput = useCallback(() => {
+        inputRef.current?.blur();
+        Keyboard.dismiss();
+    }, []);
 
     useLayoutEffect(() => {
         navigation.setOptions({
             headerLeft: ({ tintColor }) => (
                 <HeaderButton accessibilityLabel='EditPlayerBack' onPress={async () => {
+                    dismissInput();
                     navigation.goBack();
                     await logEvent('edit_player_back');
                 }}>
@@ -54,7 +63,7 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
                 </HeaderButton>
             ),
         });
-    }, [navigation, theme.tint]);
+    }, [dismissInput, navigation, theme.tint]);
     const dispatch = useAppDispatch();
     const currentGame = useAppSelector(selectCurrentGame);
     const { index, playerId } = route.params;
@@ -71,6 +80,11 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     const [isFocused, setIsFocused] = useState(false);
 
     const allPlayerNames = useAppSelector(selectAllPlayerNames);
+
+    useEffect(() => {
+        const unsubscribe = navigation.addListener('beforeRemove', dismissInput);
+        return unsubscribe;
+    }, [dismissInput, navigation]);
 
     const suggestions = useMemo(() => {
         if (!isFocused || localPlayerName.length === 0) return [];
@@ -140,9 +154,6 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
         setLocalPlayerName('');
         inputRef.current?.focus();
     };
-
-    const inputRef = React.useRef<TextInput>(null);
-    const selectedNameRef = useRef<string | null>(null);
 
     return (
         <ScrollView style={{ flex: 1 }} keyboardShouldPersistTaps="handled">

--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -4,11 +4,13 @@ import { ParamListBase, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
     NativeSyntheticEvent,
+    Platform,
     ScrollView,
     StyleSheet,
     Text,
     TextInput,
     TextInputEndEditingEventData,
+    TextInputSubmitEditingEventData,
     TouchableOpacity,
     View
 } from 'react-native';
@@ -93,21 +95,28 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
         const text = selectedNameRef.current ?? e.nativeEvent.text;
         selectedNameRef.current = null;
 
+        commitPlayerName(text);
+    };
+
+    const onSubmitEditingHandler = (e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => {
+        commitPlayerName(e.nativeEvent.text);
+    };
+
+    const onChangeHandler = (text: string) => {
+        if (text != '') {
+            savePlayerName(text);
+        }
+        setLocalPlayerName(text);
+    };
+
+    const commitPlayerName = (text: string) => {
         if (text == '') {
             setLocalPlayerName(originalPlayerName);
             savePlayerName(originalPlayerName);
         } else {
+            setLocalPlayerName(text);
             savePlayerName(text);
         }
-    };
-
-    const onChangeHandler = (text: string) => {
-        if (text == '') {
-            savePlayerName(originalPlayerName);
-        } else {
-            savePlayerName(text);
-        }
-        setLocalPlayerName(text);
     };
 
     const savePlayerName = (text: string) => {
@@ -120,13 +129,22 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     };
 
     const onFocus = () => setIsFocused(true);
-    const onBlur = () => setIsFocused(false);
+    const onBlur = () => {
+        setIsFocused(false);
+        if (localPlayerName == '') {
+            commitPlayerName(originalPlayerName);
+        }
+    };
     const onSuggestionSelect = (name: string) => {
         selectedNameRef.current = name;
         setLocalPlayerName(name);
         savePlayerName(name);
         setIsFocused(false);
         inputRef.current?.blur();
+    };
+    const clearPlayerName = () => {
+        setLocalPlayerName('');
+        inputRef.current?.focus();
     };
 
     const inputRef = React.useRef<TextInput>(null);
@@ -138,17 +156,15 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
             <View style={{ position: 'relative', zIndex: 1 }}>
                 <Input
                     ref={inputRef}
-                    rightIcon={{
+                    clearButtonMode="while-editing"
+                    rightIcon={Platform.OS === 'ios' ? undefined : {
                         style: { padding: 8 },
                         disabled: localPlayerName == '',
                         disabledStyle: { display: 'none' },
                         color: theme.textTertiary,
                         size: 15,
                         name: 'close',
-                        onPress: () => {
-                            setLocalPlayerName('');
-                            inputRef.current?.focus();
-                        }
+                        onPress: clearPlayerName,
                     }}
                     containerStyle={{ flex: 1 }}
                     inputContainerStyle={{
@@ -160,10 +176,12 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
                     maxLength={15}
                     onChangeText={onChangeHandler}
                     onEndEditing={onEndEditingHandler}
+                    onSubmitEditing={onSubmitEditingHandler}
                     onFocus={onFocus}
                     onBlur={onBlur}
                     placeholder='Player Name'
                     renderErrorMessage={false}
+                    returnKeyType="done"
                     selectTextOnFocus={true}
                     style={[styles.input, { color: theme.textSecondary }]}
                     value={localPlayerName}


### PR DESCRIPTION
## Summary
- make game title editing controlled with select-on-focus, done-submit, and native/platform clear affordances
- let player names clear locally while editing without saving blanks, then restore the original name on blur/end editing
- add focused tests for title/player clear, replacement, and restore behavior

## Tests
- npm run lint
- npm run test -- EditGame.test.tsx EditPlayerScreen.test.tsx --runInBand --watchman=false --coverage=false