### PR TITLE
Extract shared sheet chrome helpers

### DIFF
--- a/src/components/Sheets/ChooseWinnersSheet.tsx
+++ b/src/components/Sheets/ChooseWinnersSheet.tsx
@@ -1,14 +1,12 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
-    BottomSheetBackdrop,
-    BottomSheetBackdropProps,
     BottomSheetModal,
     BottomSheetScrollView
 } from '@gorhom/bottom-sheet';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Icon } from 'react-native-elements';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { shallowEqual } from 'react-redux';
 
 import { selectGameById, updateGame } from '../../../redux/GamesSlice';
@@ -18,12 +16,12 @@ import { useTheme } from '../../theme';
 
 import { useChooseWinnersSheetContext } from './ChooseWinnersSheetContext';
 import GlassButton from './GlassButton';
+import { getSheetShadowStyle, useSheetBackdrop, useSheetTopInset } from './SheetChrome';
 
 const ChooseWinnersSheet: React.FunctionComponent = () => {
     const theme = useTheme();
     const dispatch = useAppDispatch();
-    const insets = useSafeAreaInsets();
-    const topInset = insets.top + 50;
+    const topInset = useSheetTopInset(50);
 
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
     const playerIds = useAppSelector(state => selectGameById(state, currentGameId || '')?.playerIds);
@@ -64,17 +62,7 @@ const ChooseWinnersSheet: React.FunctionComponent = () => {
 
     const snapPoints = useMemo(() => ['50%', '80%'], []);
 
-    const renderBackdrop = useCallback(
-        (props: BottomSheetBackdropProps) => (
-            <BottomSheetBackdrop
-                {...props}
-                disappearsOnIndex={-1}
-                appearsOnIndex={0}
-                pressBehavior={0}
-            />
-        ),
-        []
-    );
+    const renderBackdrop = useSheetBackdrop(-1, 0);
 
     const togglePlayer = (playerId: string) => {
         setSelectedIds((prev) => {
@@ -124,7 +112,7 @@ const ChooseWinnersSheet: React.FunctionComponent = () => {
             backgroundStyle={{ backgroundColor: theme.sheetBackground }}
             handleIndicatorStyle={{ backgroundColor: theme.sheetHandle }}
             topInset={topInset}
-            style={theme.background === '#000000' ? undefined : styles.sheetShadow}
+            style={getSheetShadowStyle(theme.background)}
             accessible={false}
             accessibilityViewIsModal={false}
         >
@@ -244,13 +232,6 @@ const styles = StyleSheet.create({
     playerScore: {
         fontSize: 16,
         fontWeight: '600',
-    },
-    sheetShadow: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: -3 },
-        shadowOpacity: 0.12,
-        shadowRadius: 5,
-        elevation: 8,
     },
 });
 

--- a/src/components/Sheets/GameSheet.tsx
+++ b/src/components/Sheets/GameSheet.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { ParamListBase, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Alert, StyleSheet, Text, TouchableWithoutFeedback, View, useWindowDimensions } from 'react-native';
 import { Button } from 'react-native-elements';
 import Animated, { Extrapolate, FadeIn, interpolate, Layout, useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { asyncRematchGame, selectGameById, updateGame } from '../../../redux/GamesSlice';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
@@ -19,6 +19,7 @@ import ScoreLogTable from '../ScoreLogTable';
 
 import { useChooseWinnersSheetContext } from './ChooseWinnersSheetContext';
 import { useGameSheetContext } from './GameSheetContext';
+import { getSheetShadowStyle, useSheetBackdrop, useSheetTopInset } from './SheetChrome';
 
 /**
  * Height of the bottom sheet
@@ -44,8 +45,7 @@ const GameSheet: React.FunctionComponent = () => {
 
     const dispatch = useAppDispatch();
 
-    const insets = useSafeAreaInsets();
-    const topInset = insets.top;
+    const topInset = useSheetTopInset();
 
     // Stable key for animated children to force remount on each mount
     const mountKey = useRef(Date.now()).current;
@@ -218,17 +218,7 @@ const GameSheet: React.FunctionComponent = () => {
         };
     });
 
-    const renderBackdrop = useCallback(
-        (props: BottomSheetBackdropProps) => (
-            <BottomSheetBackdrop
-                {...props}
-                disappearsOnIndex={0}
-                appearsOnIndex={1}
-                pressBehavior={0}
-            />
-        ),
-        []
-    );
+    const renderBackdrop = useSheetBackdrop(0, 1);
 
     return (
         <BottomSheet
@@ -243,7 +233,7 @@ const GameSheet: React.FunctionComponent = () => {
             animatedPosition={animatedPosition}
             enablePanDownToClose={false}
             topInset={topInset}
-            style={theme.background === '#000000' ? undefined : styles.sheetShadow}
+            style={getSheetShadowStyle(theme.background)}
             accessible={false}
             accessibilityViewIsModal={false}
         >
@@ -381,13 +371,6 @@ const styles = StyleSheet.create({
         backgroundColor: 'rgba(0,0,0,.2)',
         borderRadius: 10,
         alignItems: 'center'
-    },
-    sheetShadow: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: -3 },
-        shadowOpacity: 0.12,
-        shadowRadius: 5,
-        elevation: 8,
     },
 });
 

--- a/src/components/Sheets/SheetChrome.tsx
+++ b/src/components/Sheets/SheetChrome.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback } from 'react';
+
+import { BottomSheetBackdrop, BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export function useSheetTopInset(offset = 0): number {
+    const insets = useSafeAreaInsets();
+    return insets.top + offset;
+}
+
+export function useSheetBackdrop(disappearsOnIndex: number, appearsOnIndex: number) {
+    return useCallback(
+        (props: BottomSheetBackdropProps) => (
+            <BottomSheetBackdrop
+                {...props}
+                disappearsOnIndex={disappearsOnIndex}
+                appearsOnIndex={appearsOnIndex}
+                pressBehavior={0}
+            />
+        ),
+        [appearsOnIndex, disappearsOnIndex]
+    );
+}
+
+export function getSheetShadowStyle(backgroundColor: string) {
+    return backgroundColor === '#000000' ? undefined : styles.sheetShadow;
+}
+
+const styles = StyleSheet.create({
+    sheetShadow: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: -3 },
+        shadowOpacity: 0.12,
+        shadowRadius: 5,
+        elevation: 8,
+    },
+});


### PR DESCRIPTION
## Summary
- add shared sheet backdrop, top inset, and shadow helpers
- use the helpers from GameSheet and ChooseWinnersSheet
- keep each sheet's BottomSheet/BottomSheetModal usage explicit

## Tests
- npm run lint