### PR TITLE
fix(android): strip dangling splashscreen_logo reference

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -120,6 +120,10 @@ export default {
   githubUrl: 'https://github.com/wyne/scorepad-react-native',
   owner: 'wyne',
   plugins: [
+    // Listed BEFORE expo-splash-screen: Expo runs the most recently registered
+    // mod first, so an earlier-listed plugin's withAndroidStyles mod runs LAST,
+    // i.e. after expo-splash-screen has written its style items.
+    './plugins/withAndroidSplashNoIcon',
     ['expo-splash-screen', {
       backgroundColor: '#F2F2F7',
       dark: { backgroundColor: '#000000' },

--- a/plugins/withAndroidSplashNoIcon.js
+++ b/plugins/withAndroidSplashNoIcon.js
@@ -1,0 +1,37 @@
+const { withAndroidStyles } = require('expo/config-plugins');
+
+/**
+ * expo-splash-screen always writes a `windowSplashScreenAnimatedIcon` item that
+ * points at `@drawable/splashscreen_logo`, even when the splash config only sets
+ * a `backgroundColor` (no image). With no icon image configured, that drawable is
+ * never generated, so a clean Android prebuild fails resource linking with:
+ *   error: resource drawable/splashscreen_logo not found
+ *
+ * We intentionally use a color-only native splash (the animated logo is handled in
+ * JS by src/components/SplashOverlay.tsx), so this plugin strips the dangling icon
+ * reference after expo-splash-screen runs. It MUST be listed AFTER
+ * 'expo-splash-screen' in the plugins array so its withAndroidStyles mod runs last.
+ */
+module.exports = (config) =>
+  withAndroidStyles(config, (config) => {
+    const styles = config.modResults.resources.style ?? [];
+    let removed = false;
+
+    for (const style of styles) {
+      if (!Array.isArray(style.item)) continue;
+      const before = style.item.length;
+      style.item = style.item.filter(
+        ({ $ }) => $.name !== 'windowSplashScreenAnimatedIcon'
+      );
+      if (style.item.length !== before) removed = true;
+    }
+
+    if (!removed) {
+      throw new Error(
+        'withAndroidSplashNoIcon: did not find a windowSplashScreenAnimatedIcon item to remove. ' +
+          'Ensure this plugin is listed after expo-splash-screen.'
+      );
+    }
+
+    return config;
+  });


### PR DESCRIPTION
## Problem

`npx eas build --profile preview --platform android --local` failed during `:app:processReleaseResources`:

```
error: resource drawable/splashscreen_logo (aka com.wyne.scorepad.preview:drawable/splashscreen_logo) not found
```

`expo-splash-screen` 56.0.10 always writes `windowSplashScreenAnimatedIcon → @drawable/splashscreen_logo` into `android/app/src/main/res/values/styles.xml`, but only **generates** that drawable when an `image`/`drawable` is configured. Our splash config is color-only by design (the animated logo is rendered in JS by `SplashOverlay`), so a clean prebuild produced a dangling reference and aapt linking failed.

The committed-but-gitignored `android/` folder was stale (from an older Expo that used `windowBackground` + shipped the PNGs), which masked this locally — EAS does a clean prebuild, so it broke there.

## Fix

- **`plugins/withAndroidSplashNoIcon.js`** — config plugin that removes the dangling `windowSplashScreenAnimatedIcon` item after `expo-splash-screen` runs. Throws if the item isn't found, so a future SDK change won't silently no-op.
- **`app.config.js`** — plugin listed **before** `expo-splash-screen`. Expo runs the most-recently-registered mod first, so an earlier-listed plugin's `withAndroidStyles` mod runs last (after expo-splash-screen has written its style items).

Native splash stays color-only as intended; no new assets needed.

## Verification

- `expo prebuild --platform android --clean` — confirmed `windowSplashScreenAnimatedIcon` / `splashscreen_logo` no longer appear in generated `styles.xml`.
- `npx eas build --profile preview --platform android --local` — `:app:processReleaseResources` passes and the build produces `app-release.apk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)