### PR TITLE
ci(claude): grant write permissions so @claude can push fixes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write # Allow Claude to push commits to PR branches
+      pull-requests: write # Allow Claude to update PRs and post review changes
+      issues: write # Allow Claude to edit/label issues it acts on
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Problem

When @wyne asked the `@claude` bot to apply a change on #669, it implemented the fix correctly but couldn't push it — "permission denied." See [this comment](https://github.com/wyne/scorepad-react-native/pull/669#discussion_r3488631024).

Root cause: the Claude Code workflow's `permissions:` block grants only read access, so the job's `GITHUB_TOKEN` can't push commits or update PRs — even though the repo's default workflow permission is already `write`. The job-level block overrides that default down to read-only.

## Change

In `.github/workflows/claude.yml`, bump the scopes the bot actually needs:

```diff
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write      # push commits to PR branches
+      pull-requests: write # update PRs / post review changes
+      issues: write        # edit/label issues it acts on
       id-token: write
       actions: read
```

## Safety

- **Forks stay read-only.** GitHub forces a read-only `GITHUB_TOKEN` for workflows triggered from forked PRs, regardless of this block — so write only ever applies to branches pushed directly to this repo.
- **Trigger is gated.** `anthropics/claude-code-action` only runs for users who already have write/admin access to the repo, so a drive-by `@claude` comment from an outside account won't get a push.
- No other workflows are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)