### PR TITLE
refactor(analytics): drop globals GA4 already auto-collects

### DIFF
--- a/src/Analytics.test.ts
+++ b/src/Analytics.test.ts
@@ -1,5 +1,4 @@
-import { getAnalytics, getAppInstanceId, getSessionId, logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
-import { Platform } from 'react-native';
+import { getAnalytics, logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
 
 import { logEvent } from './Analytics';
 import logger from './Logger';
@@ -12,64 +11,33 @@ jest.mock('./Logger', () => ({
   info: jest.fn(),
 }));
 
-// Mock Expo Application
-jest.mock('expo-application', () => ({
-  nativeApplicationVersion: '1.0.0',
-}));
-
-// Mock React Native Platform
-jest.mock('react-native', () => ({
-  Platform: {
-    OS: 'ios',
-    Version: '14.0',
-  },
-}));
-
 describe('Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (getAppInstanceId as jest.Mock).mockResolvedValue('test-app-instance-id');
-    (getSessionId as jest.Mock).mockResolvedValue('test-session-id');
     (firebaseLogEvent as jest.Mock).mockResolvedValue(undefined);
-    
-    // Reset Platform to default state
-    (Platform as unknown as { OS: string; Version: string | number }).OS = 'ios';
-    (Platform as unknown as { OS: string; Version: string | number }).Version = '14.0';
   });
 
   describe('logEvent', () => {
-    it('should log event with all required parameters', async () => {
+    it('should log the event with exactly the params provided (no injected globals)', async () => {
       const eventName = 'test_event';
       const params = { customParam: 'customValue' };
 
       await logEvent(eventName, params);
 
       expect(getAnalytics).toHaveBeenCalled();
-      expect(getAppInstanceId).toHaveBeenCalledWith(expect.anything());
-      expect(getSessionId).toHaveBeenCalledWith(expect.anything());
-      
+      // GA4 auto-collects os / appVersion / sessionId / appInstanceId — we no longer
+      // attach them, so the payload should be exactly the caller's params.
       expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {
         customParam: 'customValue',
-        appInstanceId: 'test-app-instance-id',
-        sessionId: 'test-session-id',
-        os: 'ios',
-        appVersion: '1.0.0',
-        osVersion: '14.0',
       });
     });
 
-    it('should log event without additional parameters', async () => {
+    it('should log an event with no params as an empty payload', async () => {
       const eventName = 'simple_event';
 
       await logEvent(eventName);
 
-      expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {
-        appInstanceId: 'test-app-instance-id',
-        sessionId: 'test-session-id',
-        os: 'ios',
-        appVersion: '1.0.0',
-        osVersion: '14.0',
-      });
+      expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {});
     });
 
     it('should log to console with logger', async () => {
@@ -82,59 +50,24 @@ describe('Analytics', () => {
         '\x1b[34m',
         'EVENT',
         eventName,
-        JSON.stringify({
-          testParam: 123,
-          appInstanceId: 'test-app-instance-id',
-          sessionId: 'test-session-id',
-          os: 'ios',
-          appVersion: '1.0.0',
-          osVersion: '14.0',
-        }, null, 2),
+        JSON.stringify({ testParam: 123 }, null, 2),
         '\x1b[0m'
       );
     });
 
     it('should handle empty parameters object', async () => {
       const eventName = 'empty_params_event';
-      const params = {};
 
-      await logEvent(eventName, params);
+      await logEvent(eventName, {});
 
-      expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {
-        appInstanceId: 'test-app-instance-id',
-        sessionId: 'test-session-id',
-        os: 'ios',
-        appVersion: '1.0.0',
-        osVersion: '14.0',
-      });
-    });
-
-    it('should work with different platform values', async () => {
-      // Test Android platform
-      (Platform as unknown as { OS: string; Version: string | number }).OS = 'android';
-      (Platform as unknown as { OS: string; Version: string | number }).Version = 30;
-
-      const eventName = 'android_event';
-
-      await logEvent(eventName);
-
-      expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {
-        appInstanceId: 'test-app-instance-id',
-        sessionId: 'test-session-id',
-        os: 'android',
-        appVersion: '1.0.0',
-        osVersion: 30,
-      });
+      expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {});
     });
 
     it('should propagate Firebase Analytics errors', async () => {
       const error = new Error('Firebase error');
-      (getAppInstanceId as jest.Mock).mockRejectedValue(error);
+      (firebaseLogEvent as jest.Mock).mockRejectedValue(error);
 
-      const eventName = 'error_event';
-
-      // Should not throw, but will reject
-      await expect(logEvent(eventName)).rejects.toThrow('Firebase error');
+      await expect(logEvent('error_event')).rejects.toThrow('Firebase error');
     });
 
     it('should strip null and undefined parameter values', async () => {
@@ -157,30 +90,6 @@ describe('Analytics', () => {
         booleanParam: true,
         arrayParam: [1, 2, 3],
         objectParam: { nested: 'value' },
-        appInstanceId: 'test-app-instance-id',
-        sessionId: 'test-session-id',
-        os: 'ios',
-        appVersion: '1.0.0',
-        osVersion: '14.0',
-      });
-    });
-
-
-    it('should override system params if provided in custom params', async () => {
-      const eventName = 'override_event';
-      const params = {
-        os: 'custom-os',
-        appVersion: 'custom-version',
-      };
-
-      await logEvent(eventName, params);
-
-      expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {
-        os: 'ios', // System value should override custom
-        appVersion: '1.0.0', // System value should override custom
-        appInstanceId: 'test-app-instance-id',
-        sessionId: 'test-session-id',
-        osVersion: '14.0',
       });
     });
   });

--- a/src/Analytics.ts
+++ b/src/Analytics.ts
@@ -1,22 +1,22 @@
-import { getAnalytics, getAppInstanceId, getSessionId, logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
-import * as Application from 'expo-application';
-import { Platform } from 'react-native';
+import { getAnalytics, logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
 
 import logger from './Logger';
 
 /**
  * Logs an event to Firebase Analytics with additional logging.
+ *
+ * Note: we intentionally do NOT attach os / osVersion / appVersion / sessionId /
+ * appInstanceId here. GA4 already auto-collects equivalents on every event
+ * (platform, device.operating_system_version, app_info.version, ga_session_id,
+ * user_pseudo_id), so stamping them again only duplicated first-class columns and
+ * cost two native bridge calls (getAppInstanceId/getSessionId) per event.
+ *
  * @param eventName The name of the event to log.
  * @param params The parameters of the event.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const logEvent = async (eventName: string, params?: Record<string, any>) => {
     const analytics = getAnalytics();
-    const appInstanceId = await getAppInstanceId(analytics);
-    const sessionId = await getSessionId(analytics);
-    const os = Platform.OS;
-    const osVersion = Platform.Version;
-    const appVersion = Application.nativeApplicationVersion;
 
     const sanitized = Object.fromEntries(
         Object.entries({ ...params }).filter(
@@ -24,23 +24,14 @@ export const logEvent = async (eventName: string, params?: Record<string, any>) 
         ),
     );
 
-    const fullParams = {
-        ...sanitized,
-        appInstanceId,
-        sessionId,
-        os,
-        appVersion,
-        osVersion,
-    };
-
     logger.info(
         '\x1b[34m', // Set the color to blue
         'EVENT',
         eventName,
-        JSON.stringify(fullParams, null, 2),
+        JSON.stringify(sanitized, null, 2),
         '\x1b[0m' // Reset the color
     );
 
     // Log the event to Firebase Analytics
-    await firebaseLogEvent(analytics, eventName, fullParams);
+    await firebaseLogEvent(analytics, eventName, sanitized);
 };


### PR DESCRIPTION
First of the analytics-audit PRs. Isolated, one module + its test.

## Problem

`logEvent` ([src/Analytics.ts](src/Analytics.ts)) attached five params to **every** event: `os`, `osVersion`, `appVersion`, `sessionId`, `appInstanceId`. GA4 already auto-collects equivalents on every exported row, so these just duplicated first-class BigQuery columns — and populating `sessionId`/`appInstanceId` required two awaited native bridge calls (`getSessionId`, `getAppInstanceId`) on **every** event, including the hot path (`score_change`, ~163k events).

Verified against the live BigQuery export — each custom param maps to an auto field, two of them byte-for-byte:

| custom param | GA4 auto field | relationship |
|---|---|---|
| `appVersion` | `app_info.version` | identical |
| `osVersion` | `device.operating_system_version` | auto is more complete (`iOS 26.5` vs `26.5`) |
| `os` | `platform` | same info |
| `appInstanceId` | `user_pseudo_id` | **byte-for-byte identical** |
| `sessionId` | `ga_session_id` | **same value** (custom stored as float) |

## Change

Strip the five globals from the wrapper and remove the now-unneeded `getAppInstanceId`/`getSessionId`/`Platform`/`Application` imports. The wrapper now sends exactly the caller's (sanitized) params.

## Caveats

- **Not retroactive** — historical rows keep these params; only new events omit them. No data loss.
- **Repoint dependents** — any saved query, Looker dashboard, or GA4 registered custom dimension on the custom camelCase names should switch to the built-in columns above. (The dashboards built in this audit already use the built-ins.)

## Testing
- `src/Analytics.test.ts` rewritten to assert the slimmer payload
- Full suite: 395/395 pass · `tsc` clean · eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)