### PR TITLE
fix(analytics): log real screen names instead of RNSScreen noise

### DIFF
--- a/__mocks__/@react-native-firebase/analytics.ts
+++ b/__mocks__/@react-native-firebase/analytics.ts
@@ -2,10 +2,12 @@ const mockGetAnalytics = jest.fn(() => ({}));
 const mockGetAppInstanceId = jest.fn();
 const mockGetSessionId = jest.fn();
 const mockLogEvent = jest.fn();
+const mockLogScreenView = jest.fn();
 
-export { mockGetAnalytics, mockGetAppInstanceId, mockGetSessionId, mockLogEvent };
+export { mockGetAnalytics, mockGetAppInstanceId, mockGetSessionId, mockLogEvent, mockLogScreenView };
 
 export const getAnalytics = mockGetAnalytics;
 export const getAppInstanceId = mockGetAppInstanceId;
 export const getSessionId = mockGetSessionId;
 export const logEvent = mockLogEvent;
+export const logScreenView = mockLogScreenView;

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
     "$schema": "./node_modules/@react-native-firebase/app/firebase-schema.json",
     "react-native": {
-        "crashlytics_debug_enabled": false
+        "crashlytics_debug_enabled": false,
+        "google_analytics_automatic_screen_reporting_enabled": false
     }
 }

--- a/src/Navigation.test.tsx
+++ b/src/Navigation.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { logScreenView } from '@react-native-firebase/analytics';
 import { configureStore } from '@reduxjs/toolkit';
 import { act, render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
@@ -167,6 +168,7 @@ describe('Navigation', () => {
     beforeEach(() => {
         mockActiveRouteName = 'List';
         mockNavigationContainerProps = undefined;
+        (logScreenView as jest.Mock).mockClear();
         Object.keys(mockScreenListeners).forEach((key) => {
             delete mockScreenListeners[key];
         });
@@ -253,5 +255,30 @@ describe('Navigation', () => {
         });
 
         expect(queryByTestId('game-sheet')).toBeTruthy();
+    });
+
+    it('logs a screen_view with the route name, once per navigation', () => {
+        renderNavigation();
+
+        act(() => {
+            mockNavigationContainerProps?.onReady?.();
+        });
+
+        expect((logScreenView as jest.Mock)).toHaveBeenCalledWith(
+            expect.anything(),
+            { screen_name: 'List', screen_class: 'List' },
+        );
+
+        (logScreenView as jest.Mock).mockClear();
+        setActiveRoute('Game');
+        expect((logScreenView as jest.Mock)).toHaveBeenCalledWith(
+            expect.anything(),
+            { screen_name: 'Game', screen_class: 'Game' },
+        );
+
+        // Same route fires onStateChange again — should not re-log.
+        (logScreenView as jest.Mock).mockClear();
+        setActiveRoute('Game');
+        expect((logScreenView as jest.Mock)).not.toHaveBeenCalled();
     });
 });

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
+import { getAnalytics, logScreenView } from '@react-native-firebase/analytics';
 import { DarkTheme, DefaultTheme, NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Platform, View } from 'react-native';
@@ -54,8 +55,22 @@ export const Navigation = () => {
     const fullscreen = useAppSelector(state => state.settings.home_fullscreen);
     const [showGameSheetForActiveRoute, setShowGameSheetForActiveRoute] = useState(false);
 
-    const syncGameSheetWithActiveRoute = () => {
-        setShowGameSheetForActiveRoute(navigationRef.getCurrentRoute()?.name === 'Game');
+    // Track the last logged route so we emit one screen_view per actual navigation,
+    // not on every navigation state change.
+    const loggedRouteNameRef = useRef<string | undefined>(undefined);
+
+    const handleActiveRouteChange = () => {
+        const routeName = navigationRef.getCurrentRoute()?.name;
+        setShowGameSheetForActiveRoute(routeName === 'Game');
+
+        // Manual screen tracking: automatic native reporting only sees the
+        // react-native-screens wrapper class (RNSScreen) with no name, so we log the
+        // React Navigation route name instead. Automatic reporting is disabled in
+        // firebase.json. Fire-and-forget — never block navigation on analytics.
+        if (routeName && routeName !== loggedRouteNameRef.current) {
+            loggedRouteNameRef.current = routeName;
+            logScreenView(getAnalytics(), { screen_name: routeName, screen_class: routeName });
+        }
     };
 
     return (
@@ -63,8 +78,8 @@ export const Navigation = () => {
             <NavigationContainer
                 ref={navigationRef}
                 theme={navTheme}
-                onReady={syncGameSheetWithActiveRoute}
-                onStateChange={syncGameSheetWithActiveRoute}
+                onReady={handleActiveRouteChange}
+                onStateChange={handleActiveRouteChange}
             >
                 <GestureInfoSheetContextProvider>
                     <MenuOpenContextProvider>


### PR DESCRIPTION
Part of the analytics-audit work (the screen-tracking item). Independent of #671.

## Problem

`screen_view` events were useless for telling screens apart. Verified in BigQuery (last week of June):

| `firebase_screen_class` | `firebase_screen` | events |
|---|---|---|
| `RNSScreen` | **null** | 4,743 |
| `ScreenOrientationViewController` | null | 405 |
| `UIViewController` | null | 241 |
| `RCTAlertController` | null | 169 |

Automatic native screen reporting captures the iOS `UIViewController` class. Because `react-native-screens` wraps every screen in `RNSScreen`, all 7 screens collapse into one indistinguishable bucket, the human-readable name is always null, and alerts/orientation controllers add phantom `screen_view`s. There was no manual screen logging anywhere in the app.

## Change

1. **Disable automatic native screen reporting** — `google_analytics_automatic_screen_reporting_enabled: false` in [firebase.json](firebase.json). Kills the `RNSScreen`/alert/orientation noise.
2. **Log `screen_view` manually** from `NavigationContainer`'s `onReady`/`onStateChange` ([Navigation.tsx](src/Navigation.tsx)), using the React Navigation route name (`logScreenView({ screen_name, screen_class })`). Deduped via a ref so exactly one event fires per actual navigation, not on every state change. Reuses the existing route-change handler that already drove the game sheet — fire-and-forget, never blocks navigation.

Now you get clean `List` / `Game` / `EditGame` / `Share` / `EditPlayer` / `AppSettings` / `DebugLog` screen names you can funnel on.

## Caveat

Not retroactive — historical `screen_view` rows stay `RNSScreen`/null; clean route names start from deploy.

## Testing
- New test asserts `screen_view` fires with the route name and dedupes on repeat navigation to the same route.
- Added `logScreenView` to the shared Firebase analytics mock.
- Full suite: 398/398 · `tsc` clean · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)