### PR TITLE
refactor(analytics): typed event catalog + snake_case param names

### DIFF
--- a/redux/GamesSlice.ts
+++ b/redux/GamesSlice.ts
@@ -176,7 +176,7 @@ export const asyncRematchGame = createAsyncThunk(
         dispatch(setCurrentGameId(newGameId));
 
         await logEvent('rematch_game', {
-            gameId: game.id,
+            game_id: game.id,
         });
 
         return newGameId;
@@ -250,7 +250,7 @@ export const asyncCreateGame = createAsyncThunk(
         dispatch(incrementRollingGameCounter());
 
         await logEvent('new_game', {
-            index: gameCount,
+            game_count: gameCount,
             player_count: playerCount,
         });
 

--- a/src/Analytics.test.ts
+++ b/src/Analytics.test.ts
@@ -3,7 +3,12 @@ import { getAnalytics, logEvent as firebaseLogEvent } from '@react-native-fireba
 import { logEvent } from './Analytics';
 import logger from './Logger';
 
-// Mock Firebase Analytics — uses manual mock at __mocks__/@react-native-firebase/analytics.js
+// The wrapper's runtime behavior (sanitization, logging) is event-agnostic, so these
+// tests use a loosely-typed alias to exercise it with arbitrary names / param shapes.
+// Real event/param typing is covered by the catalog (AnalyticsEvents.ts) at call sites.
+const log = logEvent as unknown as (eventName: string, params?: Record<string, unknown>) => Promise<void>;
+
+// Mock Firebase Analytics — uses manual mock at __mocks__/@react-native-firebase/analytics.ts
 jest.mock('@react-native-firebase/analytics');
 
 // Mock Logger
@@ -22,7 +27,7 @@ describe('Analytics', () => {
       const eventName = 'test_event';
       const params = { customParam: 'customValue' };
 
-      await logEvent(eventName, params);
+      await log(eventName, params);
 
       expect(getAnalytics).toHaveBeenCalled();
       // GA4 auto-collects os / appVersion / sessionId / appInstanceId — we no longer
@@ -35,7 +40,7 @@ describe('Analytics', () => {
     it('should log an event with no params as an empty payload', async () => {
       const eventName = 'simple_event';
 
-      await logEvent(eventName);
+      await log(eventName);
 
       expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {});
     });
@@ -44,7 +49,7 @@ describe('Analytics', () => {
       const eventName = 'console_test_event';
       const params = { testParam: 123 };
 
-      await logEvent(eventName, params);
+      await log(eventName, params);
 
       expect(logger.info).toHaveBeenCalledWith(
         '\x1b[34m',
@@ -58,7 +63,7 @@ describe('Analytics', () => {
     it('should handle empty parameters object', async () => {
       const eventName = 'empty_params_event';
 
-      await logEvent(eventName, {});
+      await log(eventName, {});
 
       expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {});
     });
@@ -67,7 +72,7 @@ describe('Analytics', () => {
       const error = new Error('Firebase error');
       (firebaseLogEvent as jest.Mock).mockRejectedValue(error);
 
-      await expect(logEvent('error_event')).rejects.toThrow('Firebase error');
+      await expect(log('error_event')).rejects.toThrow('Firebase error');
     });
 
     it('should strip null and undefined parameter values', async () => {
@@ -82,7 +87,7 @@ describe('Analytics', () => {
         undefinedParam: undefined,
       };
 
-      await logEvent(eventName, params);
+      await log(eventName, params);
 
       expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {
         stringParam: 'test',

--- a/src/Analytics.ts
+++ b/src/Analytics.ts
@@ -1,9 +1,13 @@
 import { getAnalytics, logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
 
+import type { AnalyticsEventParams } from './AnalyticsEvents';
 import logger from './Logger';
 
 /**
  * Logs an event to Firebase Analytics with additional logging.
+ *
+ * Events and their params are defined in the typed catalog (AnalyticsEvents.ts).
+ * A wrong event name or a mistyped/camelCase param key is a compile error.
  *
  * Note: we intentionally do NOT attach os / osVersion / appVersion / sessionId /
  * appInstanceId here. GA4 already auto-collects equivalents on every event
@@ -14,8 +18,10 @@ import logger from './Logger';
  * @param eventName The name of the event to log.
  * @param params The parameters of the event.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const logEvent = async (eventName: string, params?: Record<string, any>) => {
+export const logEvent = async <K extends keyof AnalyticsEventParams>(
+    eventName: K,
+    params?: AnalyticsEventParams[K],
+): Promise<void> => {
     const analytics = getAnalytics();
 
     const sanitized = Object.fromEntries(

--- a/src/AnalyticsEvents.ts
+++ b/src/AnalyticsEvents.ts
@@ -1,0 +1,89 @@
+/**
+ * Catalog of every analytics event and its parameter shape.
+ *
+ * Conventions (enforced by `logEvent`'s generics — see Analytics.ts):
+ *  - Event names and param keys are snake_case (GA4 convention).
+ *  - One logical field, one name everywhere (e.g. always `game_id`, never `gameId`).
+ *  - Params whose source can be undefined are optional; the wrapper strips
+ *    null/undefined before sending, so optional params simply drop out.
+ *
+ * Add new events here. A wrong event name or a mistyped/camelCase param key
+ * becomes a compile error at the call site.
+ */
+export interface AnalyticsEventParams {
+    // ── Scoring ─────────────────────────────────────────────────────────────
+    score_change: {
+        player_index: number;
+        game_id?: string;
+        /** Which configured step was used (addendOne/addendTwo), not the magnitude. */
+        addend: number;
+        round: number;
+        type: 'increment' | 'decrement';
+        power_hold: boolean;
+        notches?: number;
+        interaction: 'half-tap' | 'swipe-vertical' | 'dial';
+    };
+    round_change: {
+        game_id?: string;
+        source: string;
+        round?: number;
+        next_round?: number;
+        new_round?: boolean;
+    };
+
+    // ── Game lifecycle ──────────────────────────────────────────────────────
+    new_game: { game_count: number; player_count: number };
+    save_game: { source?: string; game_id?: string; palette?: string; player_count?: number };
+    select_game: { list_index: number; game_id: string; player_count: number; round_count: number };
+    rematch_game: { game_id: string };
+    reset_game: { game_id?: string };
+    delete_game: { list_index: number; round_count: number; player_count: number };
+    lock_game: { game_id?: string; locked: boolean; winner_count?: number };
+    edit_game: { game_id?: string };
+
+    // ── Players ─────────────────────────────────────────────────────────────
+    add_player: { game_id?: string; player_count: number };
+    remove_player: { game_id?: string; player_index: number };
+    edit_player: { game_id?: string; player_index: number };
+    edit_players: { game_id?: string; player_count: number };
+    reorder_players: { game_id?: string; player_count: number };
+    edit_player_back: Record<string, never>;
+
+    // ── Appearance / config ─────────────────────────────────────────────────
+    set_player_color: { game_id?: string; palette?: string; color: string; in_current_palette: boolean };
+    set_game_palette: { game_id?: string; palette: string };
+    interaction_type: { interaction_type: string; game_id?: string };
+    fullscreen: { fullscreen: boolean };
+    addend_sheet: { install_id?: string };
+    addend_one_change: { addend_one?: number; addend_two?: number };
+
+    // ── Score log ───────────────────────────────────────────────────────────
+    sort_by_index: { game_id?: string };
+    sort_by_score: { game_id?: string };
+
+    // ── Game sheet ──────────────────────────────────────────────────────────
+    game_sheet_close: Record<string, never>;
+    game_sheet_snap: { snap_point_index: number };
+
+    // ── Menus / navigation ──────────────────────────────────────────────────
+    menu: Record<string, never>;
+    menu_share: { round_count: number; player_count: number };
+    menu_edit: { round_count: number; player_count: number };
+    about_gestures: Record<string, never>;
+    app_info: Record<string, never>;
+    share_image: Record<string, never>;
+
+    // ── App-level ───────────────────────────────────────────────────────────
+    game_list: {
+        game_count: number;
+        app_opens?: number;
+        dev_menu_enabled?: boolean;
+        install_id?: string;
+        rolling_game_counter?: number;
+    };
+    toggle_feature: { feature: string; value: boolean; install_id?: string };
+    view_version: Record<string, never>;
+    dev_menu: { install_id?: string };
+}
+
+export type AnalyticsEventName = keyof AnalyticsEventParams;

--- a/src/components/AppInfo/RotatingIcon.tsx
+++ b/src/components/AppInfo/RotatingIcon.tsx
@@ -46,7 +46,7 @@ const RotatingIcon: React.FunctionComponent = () => {
             Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
             dispatch(toggleDevMenuEnabled());
             logEvent('dev_menu', {
-                installId,
+                install_id: installId,
             });
             rotation.value = withTiming(rotation.value + 360, { duration: 1000, easing: Easing.elastic(1) });
         } else {

--- a/src/components/Buttons/GameOptionsButton.tsx
+++ b/src/components/Buttons/GameOptionsButton.tsx
@@ -123,7 +123,7 @@ const GameOptionsButton: React.FunctionComponent = () => {
             dispatch(setGameInteractionType({ gameId: currentGameId, interactionType: type }));
         }
         dispatch(setInteractionType(type));
-        logEvent('interaction_type', { interactionType: eventName, gameId: currentGameId });
+        logEvent('interaction_type', { interaction_type: eventName, game_id: currentGameId });
     };
 
     const handleAction = (event: string) => {
@@ -140,7 +140,7 @@ const GameOptionsButton: React.FunctionComponent = () => {
             case 'point-values':
                 gameSheetRef?.current?.snapToIndex(0);
                 pointValuesSheetRef?.current?.present();
-                logEvent('addend_sheet', { installId });
+                logEvent('addend_sheet', { install_id: installId });
                 break;
             case 'fullscreen':
                 dispatch(toggleHomeFullscreen());

--- a/src/components/ColorPalettes/ColorSelector.test.tsx
+++ b/src/components/ColorPalettes/ColorSelector.test.tsx
@@ -181,10 +181,10 @@ describe('ColorSelector', () => {
 
         // Check that analytics event was logged with correct parameters
         expect(mockLogEvent).toHaveBeenCalledWith('set_player_color', {
-            gameId: 'game-1',
+            game_id: 'game-1',
             palette: 'default',
             color: '#FF0000',
-            inCurrentPalette: true,
+            in_current_palette:true,
         });
     });
 
@@ -213,10 +213,10 @@ describe('ColorSelector', () => {
 
         // Check that analytics event was logged with correct parameters
         expect(mockLogEvent).toHaveBeenCalledWith('set_player_color', {
-            gameId: 'game-1',
+            game_id: 'game-1',
             palette: 'default',
             color: '#FF6B6B',
-            inCurrentPalette: false,
+            in_current_palette:false,
         });
     });
 
@@ -377,22 +377,22 @@ describe('ColorSelector', () => {
 
         // Verify all analytics calls
         expect(mockLogEvent).toHaveBeenNthCalledWith(1, 'set_player_color', {
-            gameId: 'game-1',
+            game_id: 'game-1',
             palette: 'default',
             color: '#FF0000',
-            inCurrentPalette: true,
+            in_current_palette:true,
         });
         expect(mockLogEvent).toHaveBeenNthCalledWith(2, 'set_player_color', {
-            gameId: 'game-1',
+            game_id: 'game-1',
             palette: 'default',
             color: '#00FF00',
-            inCurrentPalette: true,
+            in_current_palette:true,
         });
         expect(mockLogEvent).toHaveBeenNthCalledWith(3, 'set_player_color', {
-            gameId: 'game-1',
+            game_id: 'game-1',
             palette: 'default',
             color: '#FF6B6B',
-            inCurrentPalette: false,
+            in_current_palette:false,
         });
     });
 

--- a/src/components/ColorPalettes/ColorSelector.tsx
+++ b/src/components/ColorPalettes/ColorSelector.tsx
@@ -44,10 +44,10 @@ const ColorSelector: React.FC<ColorSelectorProps> = ({ playerId }) => {
             changes: { color: color }
         }));
         logEvent('set_player_color', {
-            gameId: currentGameId,
+            game_id: currentGameId,
             palette: currentGame?.palette,
             color,
-            inCurrentPalette,
+            in_current_palette: inCurrentPalette,
         });
     };
 

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -81,7 +81,7 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
         navigation.navigate('Game');
 
         await logEvent('select_game', {
-            index: index,
+            list_index: index,
             game_id: gameId,
             player_count: playerIds.length,
             round_count: roundCount,

--- a/src/components/PopupMenu/AbstractPopupMenu.tsx
+++ b/src/components/PopupMenu/AbstractPopupMenu.tsx
@@ -103,7 +103,7 @@ const AbstractPopupMenu: React.FC<Props> = (props) => {
         );
 
         await logEvent('delete_game', {
-            index: props.index,
+            list_index: props.index,
             round_count: roundCount,
             player_count: playerIds.length,
         });

--- a/src/components/ScoreLogTable.test.tsx
+++ b/src/components/ScoreLogTable.test.tsx
@@ -262,7 +262,7 @@ describe('ScoreLogTable', () => {
         const playerNameColumn = getByTestId('player-name-column');
         fireEvent.press(playerNameColumn);
 
-        expect(logEvent).toHaveBeenCalledWith('sort_by_index', { gameId: 'game-1' });
+        expect(logEvent).toHaveBeenCalledWith('sort_by_index', { game_id: 'game-1' });
     });
 
     it('should handle sort by total score when total score column is pressed', () => {
@@ -298,7 +298,7 @@ describe('ScoreLogTable', () => {
         const totalScoreColumn = getByTestId('total-score-column');
         fireEvent.press(totalScoreColumn);
 
-        expect(logEvent).toHaveBeenCalledWith('sort_by_score', { gameId: 'game-1' });
+        expect(logEvent).toHaveBeenCalledWith('sort_by_score', { game_id: 'game-1' });
     });
 
     it('should handle games with single round', () => {

--- a/src/components/ScoreLogTable.tsx
+++ b/src/components/ScoreLogTable.tsx
@@ -61,12 +61,12 @@ const ScoreLogTable: React.FunctionComponent<Props> = ({ showScores = true }) =>
 
     const sortByPlayerIndex = useCallback(() => {
         dispatch(setSortSelector({ gameId: currentGameId, sortSelector: SortSelectorKey.ByIndex }));
-        logEvent('sort_by_index', { gameId: currentGameId });
+        logEvent('sort_by_index', { game_id: currentGameId });
     }, [dispatch, currentGameId]);
 
     const sortByTotalScore = useCallback(() => {
         dispatch(setSortSelector({ gameId: currentGameId, sortSelector: SortSelectorKey.ByScore }));
-        logEvent('sort_by_score', { gameId: currentGameId });
+        logEvent('sort_by_score', { game_id: currentGameId });
     }, [dispatch, currentGameId]);
 
     return (

--- a/src/components/Sheets/GameSheet.tsx
+++ b/src/components/Sheets/GameSheet.tsx
@@ -155,7 +155,7 @@ const GameSheet: React.FunctionComponent = () => {
                 logEvent('game_sheet_close');
             } else {
                 logEvent('game_sheet_snap', {
-                    snapPointIndex: snapPointIndex,
+                    snap_point_index: snapPointIndex,
                 });
 
             }

--- a/src/components/Sheets/PointValuesSheet.tsx
+++ b/src/components/Sheets/PointValuesSheet.tsx
@@ -54,7 +54,7 @@ const PointValuesSheet: React.FunctionComponent = () => {
             requestAnimationFrame(() => {
                 dispatch(setMultiplier(value));
                 dispatch(setAddendOne(value));
-                logEvent('addend_one_change', { addendOne: value });
+                logEvent('addend_one_change', { addend_one: value });
             });
         },
         [dispatch]
@@ -67,7 +67,7 @@ const PointValuesSheet: React.FunctionComponent = () => {
             requestAnimationFrame(() => {
                 dispatch(setMultiplier(value));
                 dispatch(setAddendTwo(value));
-                logEvent('addend_one_change', { addendTwo: value });
+                logEvent('addend_one_change', { addend_two: value });
             });
         },
         [dispatch]

--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -85,7 +85,7 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         logEvent('toggle_feature', {
             feature: 'point_particles',
             value: !showPointParticles,
-            installId
+            install_id: installId
         });
     };
     const togglePlayerIndexSwitch = () => {
@@ -93,7 +93,7 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         logEvent('toggle_feature', {
             feature: 'player_index',
             value: !showPlayerIndex,
-            installId
+            install_id: installId
         });
     };
     const toggleKeepAwake = () => {
@@ -110,7 +110,7 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                             logEvent('toggle_feature', {
                                 feature: 'keep_screen_awake',
                                 value: true,
-                                installId
+                                install_id: installId
                             });
                         }
                     },
@@ -121,7 +121,7 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
             logEvent('toggle_feature', {
                 feature: 'keep_screen_awake',
                 value: false,
-                installId
+                install_id: installId
             });
         }
     };

--- a/src/screens/EditGameScreen.tsx
+++ b/src/screens/EditGameScreen.tsx
@@ -48,7 +48,7 @@ const EditGameScreen: React.FunctionComponent<Props> = ({ navigation, route }) =
                 <HeaderButton accessibilityLabel='Save Game' onPress={async () => {
                     await logEvent('save_game', {
                         source: route?.params?.source,
-                        gameId: currentGame?.id,
+                        game_id: currentGame?.id,
                         palette: currentGame?.palette,
                         player_count: currentGame?.playerIds.length,
                     });

--- a/src/screens/ListScreen.test.tsx
+++ b/src/screens/ListScreen.test.tsx
@@ -259,11 +259,11 @@ describe('ListScreen', () => {
         );
 
         expect(logEvent).toHaveBeenCalledWith('game_list', {
-            gameCount: 1,
-            appOpens: 3,
-            devMenuEnabled: true,
-            installId: 'test-install-id',
-            rollingGameCounter: 1,
+            game_count: 1,
+            app_opens: 3,
+            dev_menu_enabled: true,
+            install_id: 'test-install-id',
+            rolling_game_counter: 1,
         });
     });
 
@@ -361,7 +361,7 @@ describe('ListScreen', () => {
         );
 
         expect(logEvent).toHaveBeenCalledWith('game_list', expect.objectContaining({
-            devMenuEnabled: true,
+            dev_menu_enabled: true,
         }));
     });
 

--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -46,11 +46,11 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         }
 
         logEvent('game_list', {
-            gameCount: gameIds.length,
-            appOpens,
-            devMenuEnabled,
-            installId,
-            rollingGameCounter,
+            game_count: gameIds.length,
+            app_opens: appOpens,
+            dev_menu_enabled: devMenuEnabled,
+            install_id: installId,
+            rolling_game_counter: rollingGameCounter,
         });
 
         dispatch(increaseAppOpens());


### PR DESCRIPTION
PR 2 of the analytics-audit series. Builds on #671 (merged). The high-value consistency cleanup — and the structural change that keeps the convention from drifting back.

## What

1. **New typed catalog** — [src/AnalyticsEvents.ts](src/AnalyticsEvents.ts) maps every event to its parameter shape. `logEvent` is now generic over it:
   ```ts
   export const logEvent = async <K extends keyof AnalyticsEventParams>(
       eventName: K, params?: AnalyticsEventParams[K],
   ): Promise<void> => { ... }
   ```
   A wrong event name or a mistyped/camelCase param key is now a **compile error** at the call site (excess-property checks). This is what drove the rename and what prevents future drift.

2. **snake_case normalization** — one logical field, one name everywhere:
   - `gameId` → `game_id` (save_game, set_player_color, sort_by_*, interaction_type, rematch_game)
   - overloaded `index` disambiguated → `game_count` (new_game), `list_index` (select_game, delete_game)
   - `installId` → `install_id`; `game_list` camelCase → `app_opens` / `dev_menu_enabled` / `rolling_game_counter`
   - `inCurrentPalette` → `in_current_palette`, `snapPointIndex` → `snap_point_index`, `interactionType` → `interaction_type`, `addendOne`/`addendTwo` → `addend_one`/`addend_two`

## Caveat (decided: rename & repoint)

Renamed params become **new BigQuery columns going forward — no backfill**. Repoint any saved query / Looker dashboard / registered GA4 custom dimension to the new names when this merges. Historical rows keep the old names.

## Deferred (kept this PR mechanical)

- **`await logEvent(...)` removal** — left in place to avoid `require-await` churn across ~10 files; it's cheap now that #671 removed the per-event bridge calls.
- **A real bug found**: `PointValuesSheet` logs `addend_one_change` for the *addendTwo* handler ([line 70](src/components/Sheets/PointValuesSheet.tsx#L70)) — should be `addend_two_change`. Left untouched here; will fix in the event-schema PR (PR 3).

## Testing
- Full suite: 396/396 · `tsc` clean · eslint clean
- Updated assertions in ColorSelector / ScoreLogTable / ListScreen tests; `Analytics.test.ts` rewired with a loose alias so wrapper-mechanics tests stay event-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)