### PR TITLE
refactor(analytics): unify round_change, fix addend_two_change, rename vague events

### DIFF
--- a/src/AnalyticsEvents.ts
+++ b/src/AnalyticsEvents.ts
@@ -25,10 +25,12 @@ export interface AnalyticsEventParams {
     };
     round_change: {
         game_id?: string;
+        /** What triggered the change: 'next button' | 'previous button' | 'direct select'. */
         source: string;
-        round?: number;
-        next_round?: number;
-        new_round?: boolean;
+        from_round: number;
+        to_round: number;
+        /** True when advancing created a brand-new round (was on the last round). */
+        created_round?: boolean;
     };
 
     // ── Game lifecycle ──────────────────────────────────────────────────────
@@ -52,10 +54,12 @@ export interface AnalyticsEventParams {
     // ── Appearance / config ─────────────────────────────────────────────────
     set_player_color: { game_id?: string; palette?: string; color: string; in_current_palette: boolean };
     set_game_palette: { game_id?: string; palette: string };
-    interaction_type: { interaction_type: string; game_id?: string };
+    /** Fired when the user switches the scoring interaction (swipe / half-tap / dial). */
+    set_interaction: { interaction_type: string; game_id?: string };
     fullscreen: { fullscreen: boolean };
     addend_sheet: { install_id?: string };
-    addend_one_change: { addend_one?: number; addend_two?: number };
+    addend_one_change: { addend_one: number };
+    addend_two_change: { addend_two: number };
 
     // ── Score log ───────────────────────────────────────────────────────────
     sort_by_index: { game_id?: string };
@@ -66,7 +70,8 @@ export interface AnalyticsEventParams {
     game_sheet_snap: { snap_point_index: number };
 
     // ── Menus / navigation ──────────────────────────────────────────────────
-    menu: Record<string, never>;
+    /** Header home/back button (the "bars" icon). */
+    navigate_home: Record<string, never>;
     menu_share: { round_count: number; player_count: number };
     menu_edit: { round_count: number; player_count: number };
     about_gestures: Record<string, never>;

--- a/src/components/Buttons/BackButton.tsx
+++ b/src/components/Buttons/BackButton.tsx
@@ -18,7 +18,7 @@ const BackButton: React.FunctionComponent<Props> = ({ navigation }) => {
     return (
         <HeaderButton accessibilityLabel='Home' onPress={async () => {
             navigation.goBack();
-            await logEvent('menu');
+            await logEvent('navigate_home');
         }}>
             <Icon name="bars"
                 type="font-awesome-5"

--- a/src/components/Buttons/GameOptionsButton.tsx
+++ b/src/components/Buttons/GameOptionsButton.tsx
@@ -123,7 +123,7 @@ const GameOptionsButton: React.FunctionComponent = () => {
             dispatch(setGameInteractionType({ gameId: currentGameId, interactionType: type }));
         }
         dispatch(setInteractionType(type));
-        logEvent('interaction_type', { interaction_type: eventName, game_id: currentGameId });
+        logEvent('set_interaction', { interaction_type: eventName, game_id: currentGameId });
     };
 
     const handleAction = (event: string) => {

--- a/src/components/Headers/RoundHeaderTitle.tsx
+++ b/src/components/Headers/RoundHeaderTitle.tsx
@@ -35,9 +35,9 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
         logEvent('round_change', {
             game_id: currentGameId,
             source: 'next button',
-            round: currentRoundIndex,
-            next_round: currentRoundIndex + 1,
-            new_round: isLastRound,
+            from_round: currentRoundIndex,
+            to_round: currentRoundIndex + 1,
+            created_round: isLastRound,
         });
     };
 
@@ -49,8 +49,8 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
         logEvent('round_change', {
             game_id: currentGameId,
             source: 'previous button',
-            round: currentRoundIndex,
-            next_round: currentRoundIndex - 1,
+            from_round: currentRoundIndex,
+            to_round: currentRoundIndex - 1,
         });
     };
 

--- a/src/components/ScoreLog/RoundScoreColumn.tsx
+++ b/src/components/ScoreLog/RoundScoreColumn.tsx
@@ -3,7 +3,7 @@ import React, { memo, useCallback } from 'react';
 import { LayoutChangeEvent, Text, TouchableWithoutFeedback, View } from 'react-native';
 
 import { updateGame } from '../../../redux/GamesSlice';
-import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
+import { useAppDispatch, useAppSelector, useAppStore } from '../../../redux/hooks';
 import { selectCurrentGame } from '../../../redux/selectors';
 import { logEvent } from '../../Analytics';
 
@@ -24,6 +24,7 @@ const RoundScoreColumn: React.FunctionComponent<Props> = ({
     onLayout,
 }) => {
     const dispatch = useAppDispatch();
+    const store = useAppStore();
 
     const currentGameId = useAppSelector(state => selectCurrentGame(state)?.id);
     const sortKey = useAppSelector(state => selectCurrentGame(state)?.sortSelectorKey);
@@ -33,6 +34,8 @@ const RoundScoreColumn: React.FunctionComponent<Props> = ({
     const onPressHandler = useCallback(async () => {
         if (disabled || !currentGameId) return;
 
+        // Read the round we're leaving before we change it (callback has stable deps).
+        const fromRound = selectCurrentGame(store.getState())?.roundCurrent ?? round;
         dispatch(updateGame({
             id: currentGameId,
             changes: {
@@ -42,6 +45,8 @@ const RoundScoreColumn: React.FunctionComponent<Props> = ({
         await logEvent('round_change', {
             game_id: currentGameId,
             source: 'direct select',
+            from_round: fromRound,
+            to_round: round,
         });
     }, []);
 

--- a/src/components/Sheets/PointValuesSheet.tsx
+++ b/src/components/Sheets/PointValuesSheet.tsx
@@ -67,7 +67,7 @@ const PointValuesSheet: React.FunctionComponent = () => {
             requestAnimationFrame(() => {
                 dispatch(setMultiplier(value));
                 dispatch(setAddendTwo(value));
-                logEvent('addend_one_change', { addend_two: value });
+                logEvent('addend_two_change', { addend_two: value });
             });
         },
         [dispatch]


### PR DESCRIPTION
PR 3 of the analytics-audit series. Existing-event cleanup — all changes are compiler-checked via the typed catalog from #673.

## Changes

**1. Unify `round_change` schema**
It was inconsistent across its three call sites — `direct select` carried no round numbers, `previous button` lacked the new-round flag, and the booleanish `new_round` was confusing. Now every source emits the same shape:
```ts
round_change: { game_id?, source, from_round, to_round, created_round? }
```
- next button → from/to = current/current+1, `created_round` = was-on-last-round
- previous button → from/to = current/current−1
- direct select → from = round being left (read from store at press time so it's not a stale closure), to = selected round

**2. Fix `addend_two_change` bug**
[PointValuesSheet](src/components/Sheets/PointValuesSheet.tsx) logged `addend_one_change` for the *addendTwo* handler (copy-paste bug flagged in #673). Now emits a proper `addend_two_change`.

**3. Rename vague / overloaded event names**
- `menu` → `navigate_home` — it's the header home/back button (the "bars" icon), not a menu.
- `interaction_type` → `set_interaction` — disambiguates from the `interaction` param on `score_change`.

## Caveats
- Forward-only in BigQuery (no backfill). Repoint any dashboard / registered dimension on `menu`, `interaction_type`, or the old `round_change` params (`round`/`next_round`/`new_round`).
- The `await logEvent(...)` removal stays deferred (orthogonal; cheap now after #671).

## Testing
- Full suite 396/396 · `tsc` clean · eslint clean. (No tests asserted these specific events, so no test churn.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)