### PR TITLE
feat(analytics): add theme_change, player_renamed, backup events

### DIFF
--- a/src/AnalyticsEvents.ts
+++ b/src/AnalyticsEvents.ts
@@ -50,12 +50,16 @@ export interface AnalyticsEventParams {
     edit_players: { game_id?: string; player_count: number };
     reorder_players: { game_id?: string; player_count: number };
     edit_player_back: Record<string, never>;
+    /** Fired once on leaving the edit screen if the player's name actually changed. Name itself is not logged (PII). */
+    player_renamed: { game_id?: string; player_index?: number };
 
     // ── Appearance / config ─────────────────────────────────────────────────
     set_player_color: { game_id?: string; palette?: string; color: string; in_current_palette: boolean };
     set_game_palette: { game_id?: string; palette: string };
     /** Fired when the user switches the scoring interaction (swipe / half-tap / dial). */
     set_interaction: { interaction_type: string; game_id?: string };
+    /** Color scheme preference change in settings. */
+    theme_change: { theme: 'system' | 'light' | 'dark' };
     fullscreen: { fullscreen: boolean };
     addend_sheet: { install_id?: string };
     addend_one_change: { addend_one: number };
@@ -89,6 +93,10 @@ export interface AnalyticsEventParams {
     toggle_feature: { feature: string; value: boolean; install_id?: string };
     view_version: Record<string, never>;
     dev_menu: { install_id?: string };
+    /** User confirmed restoring all data from a backup file (destructive). */
+    backup_restore: Record<string, never>;
+    /** User exported a backup of their data. */
+    backup_export: Record<string, never>;
 }
 
 export type AnalyticsEventName = keyof AnalyticsEventParams;

--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -131,12 +131,18 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
             'This will replace all current games, players, and scores with the data from the backup. This action cannot be undone.',
             [
                 { text: 'Cancel', style: 'cancel' },
-                { text: 'Restore', style: 'destructive', onPress: importBackup },
+                {
+                    text: 'Restore', style: 'destructive', onPress: () => {
+                        logEvent('backup_restore');
+                        importBackup();
+                    }
+                },
             ]
         );
     };
 
     const handleExport = async () => {
+        logEvent('backup_export');
         await exportBackup();
     };
 
@@ -191,7 +197,10 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                     <React.Fragment key={option}>
                         <TouchableOpacity
                             style={[styles.disclosureRow]}
-                            onPress={() => dispatch(setColorScheme(option))}
+                            onPress={() => {
+                                dispatch(setColorScheme(option));
+                                logEvent('theme_change', { theme: option });
+                            }}
                         >
                             <Text style={[styles.disclosureLabel, { color: theme.text }]}>
                                 {option.charAt(0).toUpperCase() + option.slice(1)}

--- a/src/screens/EditPlayerScreen.test.tsx
+++ b/src/screens/EditPlayerScreen.test.tsx
@@ -9,6 +9,7 @@ import { Provider } from 'react-redux';
 import gamesReducer from '../../redux/GamesSlice';
 import playersReducer from '../../redux/PlayersSlice';
 import settingsReducer from '../../redux/SettingsSlice';
+import * as Analytics from '../Analytics';
 
 import EditPlayerScreen from './EditPlayerScreen';
 
@@ -17,6 +18,8 @@ jest.mock('expo-font', () => ({
     isLoaded: () => true,
     loadAsync: () => Promise.resolve(),
 }));
+
+jest.mock('../Analytics', () => ({ logEvent: jest.fn() }));
 
 // Mock the components that EditPlayerScreen uses
 jest.mock('../components/ColorPalettes/ColorSelector', () => {
@@ -659,6 +662,55 @@ describe('EditPlayerScreen', () => {
         );
 
         expect(getByPlaceholderText('Player Name')).toBeTruthy();
+    });
+
+    it('logs player_renamed on leave when the name changed', () => {
+        const mockLogEvent = jest.mocked(Analytics.logEvent);
+        const store = createMockStore({
+            settings: { currentGameId: 'game-1' },
+            games: { entities: { 'game-1': mockGame }, ids: ['game-1'] },
+            players: { entities: { 'player-1': mockPlayer }, ids: ['player-1'] },
+        });
+        const mockRoute = { params: { index: 0, playerId: 'player-1' } };
+
+        const { getByDisplayValue } = render(
+            <Provider store={store}>
+                <EditPlayerScreen navigation={mockNavigation} route={mockRoute as any} />
+            </Provider>
+        );
+
+        fireEvent.changeText(getByDisplayValue('Test Player'), 'Renamed Player');
+
+        const beforeRemove = mockNavigation.addListener.mock.calls
+            .find((c: any[]) => c[0] === 'beforeRemove')?.[1];
+        act(() => beforeRemove?.());
+
+        expect(mockLogEvent).toHaveBeenCalledWith('player_renamed', {
+            game_id: 'game-1',
+            player_index: 0,
+        });
+    });
+
+    it('does not log player_renamed when the name is unchanged', () => {
+        const mockLogEvent = jest.mocked(Analytics.logEvent);
+        const store = createMockStore({
+            settings: { currentGameId: 'game-1' },
+            games: { entities: { 'game-1': mockGame }, ids: ['game-1'] },
+            players: { entities: { 'player-1': mockPlayer }, ids: ['player-1'] },
+        });
+        const mockRoute = { params: { index: 0, playerId: 'player-1' } };
+
+        render(
+            <Provider store={store}>
+                <EditPlayerScreen navigation={mockNavigation} route={mockRoute as any} />
+            </Provider>
+        );
+
+        const beforeRemove = mockNavigation.addListener.mock.calls
+            .find((c: any[]) => c[0] === 'beforeRemove')?.[1];
+        act(() => beforeRemove?.());
+
+        expect(mockLogEvent).not.toHaveBeenCalledWith('player_renamed', expect.anything());
     });
 
     it('should handle empty player name initially', () => {

--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -79,12 +79,22 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     const [localPlayerName, setLocalPlayerName] = useState<string>(player?.playerName || '');
     const [isFocused, setIsFocused] = useState(false);
 
+    // Latest committed name, kept current so the leave handler isn't a stale closure.
+    const latestNameRef = useRef<string>(player?.playerName || '');
+
     const allPlayerNames = useAppSelector(selectAllPlayerNames);
 
     useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', dismissInput);
+        const onBeforeRemove = () => {
+            dismissInput();
+            // Log a rename once per session, on any exit, if the name actually changed.
+            if (latestNameRef.current !== originalPlayerName) {
+                logEvent('player_renamed', { game_id: currentGame?.id, player_index: index });
+            }
+        };
+        const unsubscribe = navigation.addListener('beforeRemove', onBeforeRemove);
         return unsubscribe;
-    }, [dismissInput, navigation]);
+    }, [dismissInput, navigation, originalPlayerName, currentGame?.id, index]);
 
     const suggestions = useMemo(() => {
         if (!isFocused || localPlayerName.length === 0) return [];
@@ -128,6 +138,7 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     };
 
     const savePlayerName = (text: string) => {
+        latestNameRef.current = text;
         dispatch(updatePlayer({
             id: playerId,
             changes: {


### PR DESCRIPTION
PR 4 of the analytics-audit series — fills the coverage gaps. Purely additive; all events go through the typed catalog from #673.

## New events

- **`theme_change` `{ theme: 'system'|'light'|'dark' }`** — the color scheme preference ([AppSettingsScreen.tsx](src/screens/AppSettingsScreen.tsx) `setColorScheme`) was completely untracked.
- **`player_renamed` `{ game_id?, player_index? }`** — previously only `edit_player_back` fired, so we knew users *opened* the editor but not whether they actually renamed anyone. Now logged **once on leave** (via the `beforeRemove` nav listener, so it fires on back-button *or* swipe-back) and only when the name changed. The name itself is **not** logged (PII). The latest name is tracked in a ref so the leave handler isn't a stale closure.
- **`backup_restore` / `backup_export`** — destructive / high-intent data actions that had zero visibility.

## Scope notes
- Skipped the dev-menu-gated items (Load Sample Data, View Debug Log) and external link taps as low value — can revisit if you want them.
- `backup_export` added alongside `backup_restore` for symmetry (the audit flagged restore; export is the natural pair).

## Testing
- New tests in `EditPlayerScreen.test.tsx`: `player_renamed` fires on leave when the name changed, and does **not** fire when unchanged (captures the `beforeRemove` handler and invokes it).
- `theme_change`/`backup_*` follow the existing precedent (AppSettingsScreen has no test harness; its `toggle_feature` events are likewise untested).
- Full suite 398/398 · `tsc` clean · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)