### PR TITLE
feat(analytics): sync persistent settings to GA4 user properties

### DIFF
--- a/__mocks__/@react-native-firebase/analytics.ts
+++ b/__mocks__/@react-native-firebase/analytics.ts
@@ -3,11 +3,13 @@ const mockGetAppInstanceId = jest.fn();
 const mockGetSessionId = jest.fn();
 const mockLogEvent = jest.fn();
 const mockLogScreenView = jest.fn();
+const mockSetUserProperty = jest.fn();
 
-export { mockGetAnalytics, mockGetAppInstanceId, mockGetSessionId, mockLogEvent, mockLogScreenView };
+export { mockGetAnalytics, mockGetAppInstanceId, mockGetSessionId, mockLogEvent, mockLogScreenView, mockSetUserProperty };
 
 export const getAnalytics = mockGetAnalytics;
 export const getAppInstanceId = mockGetAppInstanceId;
 export const getSessionId = mockGetSessionId;
 export const logEvent = mockLogEvent;
 export const logScreenView = mockLogScreenView;
+export const setUserProperty = mockSetUserProperty;

--- a/src/Analytics.ts
+++ b/src/Analytics.ts
@@ -1,6 +1,6 @@
-import { getAnalytics, logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
+import { getAnalytics, logEvent as firebaseLogEvent, setUserProperty as firebaseSetUserProperty } from '@react-native-firebase/analytics';
 
-import type { AnalyticsEventParams } from './AnalyticsEvents';
+import type { AnalyticsEventParams, AnalyticsUserProperty } from './AnalyticsEvents';
 import logger from './Logger';
 
 /**
@@ -40,4 +40,26 @@ export const logEvent = async <K extends keyof AnalyticsEventParams>(
 
     // Log the event to Firebase Analytics
     await firebaseLogEvent(analytics, eventName, sanitized);
+};
+
+/**
+ * Sets a GA4 user property — user-scoped state you can segment on directly
+ * (vs. reconstructing it from a stream of events). Names are constrained to the
+ * catalog (AnalyticsUserProperty). Pass null to clear.
+ */
+export const setUserProperty = async (
+    name: AnalyticsUserProperty,
+    value: string | null,
+): Promise<void> => {
+    const analytics = getAnalytics();
+
+    logger.info(
+        '\x1b[35m', // magenta
+        'USER_PROPERTY',
+        name,
+        String(value),
+        '\x1b[0m'
+    );
+
+    await firebaseSetUserProperty(analytics, name, value);
 };

--- a/src/AnalyticsEvents.ts
+++ b/src/AnalyticsEvents.ts
@@ -100,3 +100,15 @@ export interface AnalyticsEventParams {
 }
 
 export type AnalyticsEventName = keyof AnalyticsEventParams;
+
+/**
+ * User-scoped properties (GA4 user properties). Unlike events, these describe the
+ * user's current state, so they can be segmented on directly rather than
+ * reconstructed from a stream of toggle events. Kept in sync from settings by
+ * useAnalyticsUserProperties.
+ */
+export type AnalyticsUserProperty =
+    | 'keep_screen_awake'
+    | 'point_particles'
+    | 'player_index'
+    | 'color_scheme';

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -18,6 +18,7 @@ import ListScreen from '../src/screens/ListScreen';
 import { MenuOpenContextProvider } from './components/MenuOpenContext';
 import GameSheet from './components/Sheets/GameSheet';
 import { GestureInfoSheetContextProvider } from './components/Sheets/GestureInfoSheetContext';
+import { useAnalyticsUserProperties } from './hooks/useAnalyticsUserProperties';
 import EditPlayerScreen from './screens/EditPlayerScreen';
 import ShareScreen from './screens/ShareScreen';
 import { useTheme } from './theme';
@@ -40,6 +41,7 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export const Navigation = () => {
+    useAnalyticsUserProperties();
     const navigationRef = useNavigationContainerRef<RootStackParamList>();
     const theme = useTheme();
     const isAndroid = Platform.OS === 'android';

--- a/src/hooks/useAnalyticsUserProperties.test.tsx
+++ b/src/hooks/useAnalyticsUserProperties.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { act, render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+
+import settingsReducer, { initialState as settingsInitialState, setColorScheme } from '../../redux/SettingsSlice';
+import { setUserProperty } from '../Analytics';
+
+import { useAnalyticsUserProperties } from './useAnalyticsUserProperties';
+
+jest.mock('../Analytics', () => ({ setUserProperty: jest.fn(), logEvent: jest.fn() }));
+
+const Harness = () => {
+    useAnalyticsUserProperties();
+    return null;
+};
+
+const makeStore = (overrides: Partial<typeof settingsInitialState> = {}) =>
+    configureStore({
+        reducer: { settings: settingsReducer },
+        preloadedState: { settings: { ...settingsInitialState, ...overrides } },
+    });
+
+describe('useAnalyticsUserProperties', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('sets every user property from settings on mount', () => {
+        const mockSet = jest.mocked(setUserProperty);
+        const store = makeStore({
+            keepScreenAwake: true,
+            showPointParticles: false,
+            showPlayerIndex: true,
+            colorScheme: 'dark',
+        });
+
+        render(<Provider store={store}><Harness /></Provider>);
+
+        expect(mockSet).toHaveBeenCalledWith('keep_screen_awake', 'true');
+        expect(mockSet).toHaveBeenCalledWith('point_particles', 'false');
+        expect(mockSet).toHaveBeenCalledWith('player_index', 'true');
+        expect(mockSet).toHaveBeenCalledWith('color_scheme', 'dark');
+    });
+
+    it('updates a user property when its setting changes', () => {
+        const mockSet = jest.mocked(setUserProperty);
+        const store = makeStore({ colorScheme: 'system' });
+
+        render(<Provider store={store}><Harness /></Provider>);
+        expect(mockSet).toHaveBeenCalledWith('color_scheme', 'system');
+
+        mockSet.mockClear();
+        act(() => { store.dispatch(setColorScheme('light')); });
+
+        expect(mockSet).toHaveBeenCalledWith('color_scheme', 'light');
+    });
+});

--- a/src/hooks/useAnalyticsUserProperties.ts
+++ b/src/hooks/useAnalyticsUserProperties.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+import { useAppSelector } from '../../redux/hooks';
+import { setUserProperty } from '../Analytics';
+
+/**
+ * Keeps GA4 user properties in sync with the user's persistent settings.
+ *
+ * Each effect fires on mount (so existing users report their current values —
+ * user properties aren't retroactive) and again whenever the setting changes.
+ * Mounted once at the app shell.
+ */
+export const useAnalyticsUserProperties = () => {
+    const keepScreenAwake = useAppSelector(state => state.settings.keepScreenAwake);
+    const pointParticles = useAppSelector(state => state.settings.showPointParticles);
+    const playerIndex = useAppSelector(state => state.settings.showPlayerIndex);
+    const colorScheme = useAppSelector(state => state.settings.colorScheme);
+
+    useEffect(() => { setUserProperty('keep_screen_awake', String(keepScreenAwake)); }, [keepScreenAwake]);
+    useEffect(() => { setUserProperty('point_particles', String(pointParticles)); }, [pointParticles]);
+    useEffect(() => { setUserProperty('player_index', String(playerIndex)); }, [playerIndex]);
+    useEffect(() => { setUserProperty('color_scheme', colorScheme); }, [colorScheme]);
+};


### PR DESCRIPTION
Adds GA4 **user properties** for persistent settings — an Ops item from the analytics audit. Independent of the remaining PR 5.

## Why

The settings toggles only emit point-in-time *events* (`toggle_feature`, `theme_change`, …). To answer "what % of active users currently have keep-awake on?" you'd have to reconstruct each user's latest toggle over time — awkward and stateful. A **user property** attaches the current value to the user as a segmentable, user-scoped dimension. There were zero `setUserProperty` calls in the app before this.

## What

- **`setUserProperty` wrapper** in [Analytics.ts](src/Analytics.ts), typed to a catalog of property names (`AnalyticsUserProperty` in [AnalyticsEvents.ts](src/AnalyticsEvents.ts)) — same compile-time safety as the event catalog.
- **`useAnalyticsUserProperties` hook** ([src/hooks/useAnalyticsUserProperties.ts](src/hooks/useAnalyticsUserProperties.ts)), mounted once in the app shell (`Navigation`), keeps four genuinely user-level preferences in sync:
  `keep_screen_awake`, `point_particles`, `player_index`, `color_scheme`.
- Each effect fires **on mount** (so existing users report their current values — user properties aren't retroactive) and **on change**.

## Deliberately excluded (game-scoped, not user-scoped)
- **`interactionType`** — the effective gesture is per-game (`Game.interactionType`, resolved by `selectInteractionType`); `settings.interactionType` is only the new-game default, so it'd be a misleading user property.
- **`home_fullscreen`** — game-context, not a stable user preference.

Numeric/transient settings (addends, current game, counters) were also left out.

## Follow-up (GA4 console)
User properties must be **registered** in GA4 (Admin → Custom definitions → User properties) before they appear in reports/audiences — a one-time console step.

## Testing
- New `useAnalyticsUserProperties.test.tsx`: asserts all four are set from settings on mount, and that a property updates when its setting changes.
- Added `setUserProperty` to the shared Firebase analytics mock.
- Full suite green · `tsc` clean · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)