### PR TITLE
Validate backups before restoring Redux state

### DIFF
--- a/redux/backup.test.ts
+++ b/redux/backup.test.ts
@@ -1,0 +1,150 @@
+import * as DocumentPicker from 'expo-document-picker';
+import { Alert } from 'react-native';
+
+import { InteractionType } from '../src/components/Interactions/InteractionType';
+
+import { importBackup, parseBackupData } from './backup';
+import { initialState as initialSettings } from './SettingsSlice';
+
+const mockDispatch = jest.fn();
+let mockFileContent = '';
+
+jest.mock('./store', () => ({
+    store: {
+        dispatch: (...args: unknown[]) => mockDispatch(...args),
+        getState: jest.fn(),
+    },
+}));
+
+jest.mock('expo-document-picker', () => ({
+    getDocumentAsync: jest.fn(),
+}));
+
+jest.mock('expo-file-system', () => ({
+    Paths: { cache: '/cache' },
+    File: jest.fn().mockImplementation(() => ({
+        create: jest.fn(),
+        text: jest.fn(() => Promise.resolve(mockFileContent)),
+        uri: 'file:///backup.json',
+        write: jest.fn(),
+    })),
+}));
+
+jest.mock('expo-sharing', () => ({
+    isAvailableAsync: jest.fn(),
+    shareAsync: jest.fn(),
+}));
+
+const createValidBackup = () => ({
+    version: 1,
+    exportedAt: 1_750_000_000_000,
+    games: {
+        ids: ['game-1'],
+        entities: {
+            'game-1': {
+                id: 'game-1',
+                title: 'Test Game',
+                dateCreated: 1_750_000_000_000,
+                roundCurrent: 0,
+                roundTotal: 1,
+                playerIds: ['player-1'],
+                interactionType: InteractionType.SwipeVertical,
+            },
+        },
+    },
+    players: {
+        ids: ['player-1'],
+        entities: {
+            'player-1': {
+                id: 'player-1',
+                playerName: 'Player 1',
+                scores: [0],
+            },
+        },
+    },
+    settings: {
+        ...initialSettings,
+        currentGameId: 'game-1',
+        _persist: {
+            rehydrated: true,
+            version: 4,
+        },
+    },
+});
+
+describe('backup validation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    });
+
+    it('accepts a complete backup and strips Redux Persist metadata', () => {
+        const parsed = parseBackupData(createValidBackup());
+
+        expect(parsed).toBeDefined();
+        expect(parsed?.settings.currentGameId).toBe('game-1');
+        expect(parsed?.settings).not.toHaveProperty('_persist');
+    });
+
+    it.each([
+        ['unsupported version', (backup: ReturnType<typeof createValidBackup>) => {
+            backup.version = 99;
+        }],
+        ['missing settings', (backup: ReturnType<typeof createValidBackup>) => {
+            delete (backup as Partial<typeof backup>).settings;
+        }],
+        ['mismatched entity ids', (backup: ReturnType<typeof createValidBackup>) => {
+            backup.games.ids = ['missing-game'];
+        }],
+        ['dangling player reference', (backup: ReturnType<typeof createValidBackup>) => {
+            backup.games.entities['game-1'].playerIds = ['missing-player'];
+        }],
+        ['invalid score', (backup: ReturnType<typeof createValidBackup>) => {
+            backup.players.entities['player-1'].scores = [Number.NaN];
+        }],
+        ['missing current game', (backup: ReturnType<typeof createValidBackup>) => {
+            backup.settings.currentGameId = 'missing-game';
+        }],
+    ])('rejects %s', (_description, mutate) => {
+        const backup = createValidBackup();
+        mutate(backup);
+
+        expect(parseBackupData(backup)).toBeUndefined();
+    });
+
+    it('does not dispatch any restore actions for invalid backup data', async () => {
+        mockFileContent = JSON.stringify({
+            games: { entities: {} },
+            players: { entities: {} },
+        });
+        (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValue({
+            canceled: false,
+            assets: [{ uri: 'file:///backup.json' }],
+        });
+
+        await importBackup();
+
+        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(Alert.alert).toHaveBeenCalledWith(
+            'Import Failed',
+            'The selected file is not a valid ScorePad backup.'
+        );
+    });
+
+    it('dispatches all restore actions only after a backup passes validation', async () => {
+        mockFileContent = JSON.stringify(createValidBackup());
+        expect(parseBackupData(JSON.parse(mockFileContent))).toBeDefined();
+        (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValue({
+            canceled: false,
+            assets: [{ uri: 'file:///backup.json' }],
+        });
+
+        await importBackup();
+
+        expect(Alert.alert).toHaveBeenCalledWith(
+            'Restore Complete',
+            'Your data has been restored from the backup.'
+        );
+        expect(mockDispatch).toHaveBeenCalledTimes(3);
+    });
+});

--- a/redux/backup.ts
+++ b/redux/backup.ts
@@ -3,9 +3,12 @@ import { Paths, File } from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import { Alert } from 'react-native';
 
+import { InteractionType } from '../src/components/Interactions/InteractionType';
+import { SortDirectionKey, SortSelectorKey } from '../src/components/ScoreLog/SortHelper';
+
 import { GameState, restoreAllGames } from './GamesSlice';
 import { ScoreState, restoreAllPlayers } from './PlayersSlice';
-import { restoreSettings, SettingsState } from './SettingsSlice';
+import { initialState as initialSettings, restoreSettings, SettingsState } from './SettingsSlice';
 import { store } from './store';
 
 const BACKUP_VERSION = 1;
@@ -23,6 +26,149 @@ interface BackupData {
     };
     settings: SettingsState;
 }
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const isFiniteNumber = (value: unknown): value is number => (
+    typeof value === 'number' && Number.isFinite(value)
+);
+
+const isStringArray = (value: unknown): value is string[] => (
+    Array.isArray(value) && value.every(item => typeof item === 'string')
+);
+
+const hasMatchingIds = (ids: string[], entities: Record<string, unknown>): boolean => {
+    const entityIds = Object.keys(entities);
+    return ids.length === entityIds.length
+        && new Set(ids).size === ids.length
+        && ids.every(id => Object.hasOwn(entities, id));
+};
+
+const isInteractionType = (value: unknown): value is InteractionType => (
+    typeof value === 'string' && Object.values(InteractionType).includes(value as InteractionType)
+);
+
+const isGameState = (
+    value: unknown,
+    id: string,
+    playerEntities: Record<string, unknown>
+): value is GameState => {
+    if (!isRecord(value)) return false;
+    if (value.id !== id || typeof value.title !== 'string') return false;
+    if (!isFiniteNumber(value.dateCreated)) return false;
+    if (!Number.isInteger(value.roundCurrent) || (value.roundCurrent as number) < 0) return false;
+    if (!Number.isInteger(value.roundTotal) || (value.roundTotal as number) < 1) return false;
+    if ((value.roundCurrent as number) >= (value.roundTotal as number)) return false;
+    const playerIds = value.playerIds;
+    if (!isStringArray(playerIds) || new Set(playerIds).size !== playerIds.length) return false;
+    if (!playerIds.every(playerId => Object.hasOwn(playerEntities, playerId))) return false;
+
+    if (value.locked !== undefined && typeof value.locked !== 'boolean') return false;
+    if (value.winnerIds !== undefined) {
+        if (!isStringArray(value.winnerIds)) return false;
+        if (!value.winnerIds.every(winnerId => playerIds.includes(winnerId))) return false;
+    }
+    if (
+        value.sortSelectorKey !== undefined
+        && !Object.values(SortSelectorKey).includes(value.sortSelectorKey as SortSelectorKey)
+    ) return false;
+    if (
+        value.sortDirectionKey !== undefined
+        && !Object.values(SortDirectionKey).includes(value.sortDirectionKey as SortDirectionKey)
+    ) return false;
+    if (value.palette !== undefined && typeof value.palette !== 'string') return false;
+    if (value.interactionType !== undefined && !isInteractionType(value.interactionType)) return false;
+
+    return true;
+};
+
+const isScoreState = (value: unknown, id: string): value is ScoreState => {
+    if (!isRecord(value)) return false;
+    return value.id === id
+        && typeof value.playerName === 'string'
+        && Array.isArray(value.scores)
+        && value.scores.every(isFiniteNumber)
+        && (value.color === undefined || typeof value.color === 'string');
+};
+
+const isSettingsState = (value: unknown, gameEntities: Record<string, unknown>): value is SettingsState => {
+    if (!isRecord(value)) return false;
+
+    const currentGameIdIsValid = value.currentGameId === undefined
+        || (
+            typeof value.currentGameId === 'string'
+            && Object.hasOwn(gameEntities, value.currentGameId)
+        );
+
+    return typeof value.home_fullscreen === 'boolean'
+        && isFiniteNumber(value.multiplier)
+        && isFiniteNumber(value.addendOne)
+        && isFiniteNumber(value.addendTwo)
+        && currentGameIdIsValid
+        && typeof value.showPointParticles === 'boolean'
+        && typeof value.showPlayerIndex === 'boolean'
+        && isInteractionType(value.interactionType)
+        && (value.lastUsedInteractionType === undefined || isInteractionType(value.lastUsedInteractionType))
+        && isFiniteNumber(value.lastStoreReviewPrompt)
+        && (value.devMenuEnabled === undefined || typeof value.devMenuEnabled === 'boolean')
+        && Number.isInteger(value.appOpens)
+        && (value.installId === undefined || typeof value.installId === 'string')
+        && (value.rollingGameCounter === undefined || Number.isInteger(value.rollingGameCounter))
+        && typeof value.keepScreenAwake === 'boolean'
+        && isStringArray(value.seenFeatureNotifications)
+        && ['system', 'light', 'dark'].includes(value.colorScheme as string);
+};
+
+export const parseBackupData = (value: unknown): BackupData | undefined => {
+    if (!isRecord(value) || value.version !== BACKUP_VERSION || !isFiniteNumber(value.exportedAt)) {
+        return undefined;
+    }
+    if (!isRecord(value.games) || !isRecord(value.players)) return undefined;
+    if (!isRecord(value.games.entities) || !isStringArray(value.games.ids)) return undefined;
+    if (!isRecord(value.players.entities) || !isStringArray(value.players.ids)) return undefined;
+
+    const gameEntities = value.games.entities;
+    const gameIds = value.games.ids;
+    const playerEntities = value.players.entities;
+    const playerIds = value.players.ids;
+
+    if (!hasMatchingIds(gameIds, gameEntities)) return undefined;
+    if (!hasMatchingIds(playerIds, playerEntities)) return undefined;
+    if (!Object.entries(playerEntities).every(([id, player]) => isScoreState(player, id))) {
+        return undefined;
+    }
+    if (
+        !Object.entries(gameEntities).every(
+            ([id, game]) => isGameState(game, id, playerEntities)
+        )
+    ) {
+        return undefined;
+    }
+    if (!isSettingsState(value.settings, gameEntities)) return undefined;
+
+    const settings = Object.fromEntries(
+        Object.entries(value.settings).filter(([key]) => key !== '_persist')
+    ) as unknown as SettingsState;
+
+    return {
+        version: BACKUP_VERSION,
+        exportedAt: value.exportedAt,
+        games: {
+            entities: gameEntities as Record<string, GameState>,
+            ids: gameIds,
+        },
+        players: {
+            entities: playerEntities as Record<string, ScoreState>,
+            ids: playerIds,
+        },
+        settings: {
+            ...initialSettings,
+            ...settings,
+        },
+    };
+};
 
 export const exportBackup = async (): Promise<void> => {
     try {
@@ -74,15 +220,16 @@ export const importBackup = async (): Promise<void> => {
         const backupFile = new File(file.uri);
         const content = await backupFile.text();
 
-        let backup: BackupData;
+        let parsed: unknown;
         try {
-            backup = JSON.parse(content);
+            parsed = JSON.parse(content);
         } catch {
             Alert.alert('Import Failed', 'The selected file is not a valid JSON file.');
             return;
         }
 
-        if (!backup.games?.entities || !backup.players?.entities) {
+        const backup = parseBackupData(parsed);
+        if (!backup) {
             Alert.alert('Import Failed', 'The selected file is not a valid ScorePad backup.');
             return;
         }


### PR DESCRIPTION
## Summary
- parse backup JSON as unknown and validate its complete runtime shape
- reject unsupported versions, invalid entity IDs, malformed games and players, dangling references, and invalid settings
- ensure the current game references a restored game
- strip Redux Persist metadata before restoring settings
- dispatch no restore actions unless the entire backup passes validation
- add focused import and validation coverage

## Validation
- npm run lint
- npm run test -- --runInBand --no-watchman
- 41 suites passed, 407 tests passed