### PR TITLE
Cascade game deletion to orphaned players

### DIFF
--- a/redux/GamesSlice.test.ts
+++ b/redux/GamesSlice.test.ts
@@ -4,14 +4,15 @@ import { configureStore, EntityState, Store } from '@reduxjs/toolkit';
 import gamesReducer, {
     asyncCreateGame,
     asyncRematchGame,
-    gameDelete,
+    deleteGameAndPlayers,
     gameSave,
     GameState,
     roundNext,
     roundPrevious,
     selectAllGames
 } from './GamesSlice';
-import playersReducer from './PlayersSlice';
+import playersReducer, { playerAdd } from './PlayersSlice';
+import settingsReducer, { initialState as initialSettings } from './SettingsSlice';
 
 jest.mock('@react-native-firebase/analytics', () => {
     return () => ({
@@ -108,14 +109,6 @@ describe('games reducer', () => {
         expect(tiedIds).toEqual(['a-game', 'z-game']);
     });
 
-    it('should handle gameDelete', () => {
-        store.dispatch(gameDelete('game1'));
-
-        const state = store.getState();
-        expect(state.entities.game1).toBeUndefined();
-        expect(state.ids).not.toContain('game1');
-    });
-
     it('should select all games', () => {
         const initialState = {
             games: {
@@ -206,5 +199,87 @@ describe('asyncRematchGame', () => {
 
         expect(finalState.players.entities[finalState.players.ids[2]]?.scores).toEqual([0]);
         expect(finalState.players.entities[finalState.players.ids[3]]?.scores).toEqual([0]);
+    });
+});
+
+describe('deleteGameAndPlayers', () => {
+    it('removes unreferenced players, preserves shared players, and clears the current game', () => {
+        const store = configureStore({
+            reducer: {
+                games: gamesReducer,
+                players: playersReducer,
+                settings: settingsReducer,
+            },
+            preloadedState: {
+                games: {
+                    ids: ['game-1', 'game-2'],
+                    entities: {
+                        'game-1': {
+                            id: 'game-1',
+                            title: 'Game 1',
+                            dateCreated: 1,
+                            roundCurrent: 0,
+                            roundTotal: 1,
+                            playerIds: ['player-1', 'shared-player'],
+                        },
+                        'game-2': {
+                            id: 'game-2',
+                            title: 'Game 2',
+                            dateCreated: 2,
+                            roundCurrent: 0,
+                            roundTotal: 1,
+                            playerIds: ['shared-player'],
+                        },
+                    },
+                },
+                players: {
+                    ids: ['player-1', 'shared-player'],
+                    entities: {
+                        'player-1': {
+                            id: 'player-1',
+                            playerName: 'Player 1',
+                            scores: [0],
+                        },
+                        'shared-player': {
+                            id: 'shared-player',
+                            playerName: 'Shared Player',
+                            scores: [0],
+                        },
+                    },
+                },
+                settings: {
+                    ...initialSettings,
+                    currentGameId: 'game-1',
+                },
+            },
+        });
+
+        store.dispatch(deleteGameAndPlayers('game-1'));
+
+        const state = store.getState();
+        expect(state.games.entities['game-1']).toBeUndefined();
+        expect(state.games.entities['game-2']).toBeDefined();
+        expect(state.players.entities['player-1']).toBeUndefined();
+        expect(state.players.entities['shared-player']).toBeDefined();
+        expect(state.settings.currentGameId).toBeUndefined();
+    });
+
+    it('does nothing when the game does not exist', () => {
+        const store = configureStore({
+            reducer: {
+                games: gamesReducer,
+                players: playersReducer,
+                settings: settingsReducer,
+            },
+        });
+        store.dispatch(playerAdd({
+            id: 'player-1',
+            playerName: 'Player 1',
+            scores: [0],
+        }));
+
+        store.dispatch(deleteGameAndPlayers('missing-game'));
+
+        expect(store.getState().players.entities['player-1']).toBeDefined();
     });
 });

--- a/redux/GamesSlice.ts
+++ b/redux/GamesSlice.ts
@@ -1,4 +1,4 @@
-import { PayloadAction, createAsyncThunk, createEntityAdapter, createSelector, createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, ThunkAction, UnknownAction, createAsyncThunk, createEntityAdapter, createSelector, createSlice } from '@reduxjs/toolkit';
 import { getContrastRatio } from 'colorsheet';
 import * as Crypto from 'expo-crypto';
 
@@ -8,7 +8,7 @@ import { InteractionType } from '../src/components/Interactions/InteractionType'
 import { SortDirectionKey, SortSelectorKey } from '../src/components/ScoreLog/SortHelper';
 import logger from '../src/Logger';
 
-import { playerAdd, selectPlayerById, updatePlayer } from './PlayersSlice';
+import { playerAdd, removePlayer, selectPlayerById, updatePlayer } from './PlayersSlice';
 import { incrementRollingGameCounter, setCurrentGameId } from './SettingsSlice';
 import { RootState } from './store';
 
@@ -129,9 +129,34 @@ const gamesSlice = createSlice({
     }
 });
 
+const { gameDelete } = gamesSlice.actions;
+
 interface GamesSlice {
     games: typeof initialState;
 }
+
+export const deleteGameAndPlayers = (
+    gameId: string
+): ThunkAction<void, RootState, unknown, UnknownAction> => (dispatch, getState) => {
+    const state = getState();
+    const game = selectGameById(state, gameId);
+    if (!game) return;
+
+    const playerIdsUsedByOtherGames = new Set(
+        Object.values(state.games.entities)
+            .filter(otherGame => otherGame?.id !== gameId)
+            .flatMap(otherGame => otherGame?.playerIds ?? [])
+    );
+
+    dispatch(gameDelete(gameId));
+    game.playerIds
+        .filter(playerId => !playerIdsUsedByOtherGames.has(playerId))
+        .forEach(playerId => dispatch(removePlayer(playerId)));
+
+    if (state.settings.currentGameId === gameId) {
+        dispatch(setCurrentGameId(undefined));
+    }
+};
 
 export const asyncRematchGame = createAsyncThunk(
     'games/rematch',
@@ -338,7 +363,6 @@ export const {
     roundNext,
     roundPrevious,
     gameSave,
-    gameDelete,
     setSortSelector,
     reorderPlayers,
     setGameInteractionType,

--- a/redux/SettingsSlice.ts
+++ b/redux/SettingsSlice.ts
@@ -47,7 +47,7 @@ const settingsSlice = createSlice({
     name: 'settings',
     initialState,
     reducers: {
-        setCurrentGameId(state, action: PayloadAction<string>) {
+        setCurrentGameId(state, action: PayloadAction<string | undefined>) {
             console.info('Setting Current Game: ', action.payload);
             state.currentGameId = action.payload;
         },

--- a/src/components/GameListItem.test.tsx
+++ b/src/components/GameListItem.test.tsx
@@ -7,7 +7,7 @@ import { act, fireEvent, render } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 import { Provider } from 'react-redux';
 
-import gamesReducer, { gameDelete, roundNext } from '../../redux/GamesSlice';
+import gamesReducer, { deleteGameAndPlayers, roundNext } from '../../redux/GamesSlice';
 import playersReducer from '../../redux/PlayersSlice';
 import settingsReducer from '../../redux/SettingsSlice';
 
@@ -187,7 +187,7 @@ describe('GameListItem', () => {
         expect(getByText('Test Game')).toBeTruthy();
 
         act(() => {
-            store.dispatch(gameDelete('game-1'));
+            store.dispatch(deleteGameAndPlayers('game-1'));
         });
 
         expect(toJSON()).toBeNull();

--- a/src/components/PopupMenu/AbstractPopupMenu.tsx
+++ b/src/components/PopupMenu/AbstractPopupMenu.tsx
@@ -5,7 +5,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Alert, Platform } from 'react-native';
 import { shallowEqual } from 'react-redux';
 
-import { asyncRematchGame, gameDelete, selectGameById } from '../../../redux/GamesSlice';
+import { asyncRematchGame, deleteGameAndPlayers, selectGameById } from '../../../redux/GamesSlice';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { logEvent } from '../../Analytics';
 
@@ -95,18 +95,17 @@ const AbstractPopupMenu: React.FC<Props> = (props) => {
                 {
                     text: 'OK',
                     onPress: () => {
-                        dispatch(gameDelete(props.gameId));
+                        dispatch(deleteGameAndPlayers(props.gameId));
+                        void logEvent('delete_game', {
+                            list_index: props.index,
+                            round_count: roundCount,
+                            player_count: playerIds.length,
+                        });
                     }
                 },
             ],
             { cancelable: false },
         );
-
-        void logEvent('delete_game', {
-            list_index: props.index,
-            round_count: roundCount,
-            player_count: playerIds.length,
-        });
     };
 
     return Platform.select({


### PR DESCRIPTION
## Summary
- replace direct game deletion with a single typed cascade thunk
- remove players that are no longer referenced by any game
- preserve players still referenced by another game
- clear currentGameId when its game is deleted
- keep the raw game-delete action private so callers cannot bypass cleanup
- log deletion analytics only after the user confirms deletion
- add reducer-level coverage for deletion and shared-player preservation

## Validation
- npm run lint
- npm run test -- --runInBand --no-watchman
- 41 suites passed, 401 tests passed