### PR TITLE
feat(analytics): add game_complete event with outcome stats

### DIFF
--- a/src/AnalyticsEvents.ts
+++ b/src/AnalyticsEvents.ts
@@ -1,3 +1,5 @@
+import type { InteractionType } from './components/Interactions/InteractionType';
+
 /**
  * Catalog of every analytics event and its parameter shape.
  *
@@ -41,6 +43,20 @@ export interface AnalyticsEventParams {
     reset_game: { game_id?: string };
     delete_game: { list_index: number; round_count: number; player_count: number };
     lock_game: { game_id?: string; locked: boolean; winner_count?: number };
+    /**
+     * A game was finished (locked with winners optional). Companion to
+     * lock_game(locked:true) — this carries the outcome stats.
+     */
+    game_complete: {
+        game_id?: string;
+        player_count: number;
+        round_count: number;
+        winner_count: number;
+        duration_sec: number;
+        palette?: string;
+        /** The scoring gesture the game used (per-game, falls back to the default). */
+        interaction: InteractionType;
+    };
     edit_game: { game_id?: string };
 
     // ── Players ─────────────────────────────────────────────────────────────

--- a/src/components/Sheets/ChooseWinnersSheet.test.tsx
+++ b/src/components/Sheets/ChooseWinnersSheet.test.tsx
@@ -282,4 +282,20 @@ describe('ChooseWinnersSheet', () => {
             winner_count: 0,
         });
     });
+
+    it('should log game_complete with outcome stats when locking', () => {
+        const store = createMockStore(mockPlayers, 'game-1', ['player-1', 'player-2', 'player-3']);
+        const { getByText, getByLabelText } = render(<Provider store={store}><ChooseWinnersSheet /></Provider>);
+
+        fireEvent.press(getByText('Bob'));
+        fireEvent.press(getByLabelText('Lock Game'));
+
+        expect(logEvent).toHaveBeenCalledWith('game_complete', expect.objectContaining({
+            game_id: 'game-1',
+            player_count: 3,
+            round_count: 1,
+            winner_count: 1,
+            interaction: 'swipe-vertical', // resolved default for this game
+        }));
+    });
 });

--- a/src/components/Sheets/ChooseWinnersSheet.tsx
+++ b/src/components/Sheets/ChooseWinnersSheet.tsx
@@ -13,6 +13,7 @@ import { shallowEqual } from 'react-redux';
 
 import { selectGameById, updateGame } from '../../../redux/GamesSlice';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
+import { selectInteractionType } from '../../../redux/selectors';
 import { logEvent } from '../../Analytics';
 import { useTheme } from '../../theme';
 
@@ -26,7 +27,9 @@ const ChooseWinnersSheet: React.FunctionComponent = () => {
     const topInset = insets.top + 50;
 
     const currentGameId = useAppSelector(state => state.settings.currentGameId);
-    const playerIds = useAppSelector(state => selectGameById(state, currentGameId || '')?.playerIds);
+    const currentGame = useAppSelector(state => selectGameById(state, currentGameId || ''));
+    const interactionType = useAppSelector(state => selectInteractionType(state, currentGameId));
+    const playerIds = currentGame?.playerIds;
     const allPlayers = useAppSelector((state) =>
         (playerIds || []).map((id) => state.players.entities[id]),
         shallowEqual
@@ -105,6 +108,19 @@ const ChooseWinnersSheet: React.FunctionComponent = () => {
             locked: true,
             winner_count: selectedIds.size,
         });
+
+        logEvent('game_complete', {
+            game_id: currentGameId,
+            player_count: (playerIds ?? []).length,
+            round_count: currentGame?.roundTotal ?? 0,
+            winner_count: selectedIds.size,
+            duration_sec: currentGame?.dateCreated
+                ? Math.round((Date.now() - currentGame.dateCreated) / 1000)
+                : 0,
+            palette: currentGame?.palette,
+            interaction: interactionType,
+        });
+
         setSelectedIds(new Set());
         chooseWinnersSheetRef?.current?.close();
     };


### PR DESCRIPTION
Final code PR of the analytics-audit series. Closes the "we only know a game *locked*, not how it ended" gap.

## What

Locking a game in [ChooseWinnersSheet](src/components/Sheets/ChooseWinnersSheet.tsx) is the completion point, but it only logged `lock_game { winner_count }`. This adds a dedicated **`game_complete`** event fired alongside it with the outcome:

```
game_id, player_count, round_count, winner_count, duration_sec, palette, interaction
```

- **`round_count`** = rounds played; **`duration_sec`** from the game's `dateCreated`.
- **`interaction`** = the scoring gesture the game used, resolved **per-game** (`Game.interactionType`, falling back to the default) via `selectInteractionType` — so you can compare outcomes/length across swipe vs half-tap vs dial.
- Computed from data already on screen plus the game record.

Kept as its own event rather than overloading `lock_game` with flag-dependent params — `lock_game` stays a clean lock/unlock toggle, and `game_complete` is a first-class "a game finished" signal you can funnel on.

## Testing
- New test: locking a 3-player / 1-round game asserts `game_complete` with `player_count: 3`, `round_count: 1`, `winner_count: 1`, `interaction: 'swipe-vertical'`.
- Full suite green · `tsc` clean · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)