### PR TITLE
Stabilize entity adapter sort comparators

### DIFF
--- a/redux/GamesSlice.test.ts
+++ b/redux/GamesSlice.test.ts
@@ -85,6 +85,29 @@ describe('games reducer', () => {
         expect(state.ids).toContain('game1');
     });
 
+    it('uses game id as a deterministic tie-breaker for equal creation dates', () => {
+        const dateCreated = Date.now();
+        store.dispatch(gameSave({
+            id: 'z-game',
+            title: 'Z Game',
+            dateCreated,
+            roundCurrent: 0,
+            roundTotal: 1,
+            playerIds: [],
+        }));
+        store.dispatch(gameSave({
+            id: 'a-game',
+            title: 'A Game',
+            dateCreated,
+            roundCurrent: 0,
+            roundTotal: 1,
+            playerIds: [],
+        }));
+
+        const tiedIds = store.getState().ids.filter(id => id !== 'game1');
+        expect(tiedIds).toEqual(['a-game', 'z-game']);
+    });
+
     it('should handle gameDelete', () => {
         store.dispatch(gameDelete('game1'));
 

--- a/redux/GamesSlice.ts
+++ b/redux/GamesSlice.ts
@@ -30,7 +30,9 @@ export interface GameState {
 }
 
 const gamesAdapter = createEntityAdapter({
-    sortComparer: (a: GameState, b: GameState) => (a.dateCreated < b.dateCreated) ? 1 : -1,
+    sortComparer: (a: GameState, b: GameState) => (
+        b.dateCreated - a.dateCreated || a.id.localeCompare(b.id)
+    ),
 });
 
 const initialState = gamesAdapter.getInitialState({

--- a/redux/PlayersSlice.test.ts
+++ b/redux/PlayersSlice.test.ts
@@ -226,8 +226,22 @@ describe('player sort order', () => {
             scores: [30],
         }));
         const ordered = selectAllPlayers({ players }).map((p) => p.id);
-        expect(ordered).toHaveLength(2);
-        expect(ordered).toEqual(expect.arrayContaining(['a', 'b']));
+        expect(ordered).toEqual(['a', 'b']);
+    });
+
+    it('uses player id as a deterministic tie-breaker regardless of insertion order', () => {
+        let players = playersReducer(undefined, playerAdd({
+            id: 'z',
+            playerName: 'Z',
+            scores: [30],
+        }));
+        players = playersReducer(players, playerAdd({
+            id: 'a',
+            playerName: 'A',
+            scores: [10, 20],
+        }));
+
+        expect(selectAllPlayers({ players }).map((player) => player.id)).toEqual(['a', 'z']);
     });
 });
 

--- a/redux/PlayersSlice.ts
+++ b/redux/PlayersSlice.ts
@@ -15,7 +15,7 @@ export interface ScoreState {
 
 const playersAdapter = createEntityAdapter({
     sortComparer: (a: ScoreState, b: ScoreState) => (
-        grandTotalScore(a.scores) < grandTotalScore(b.scores) ? 1 : -1
+        grandTotalScore(b.scores) - grandTotalScore(a.scores) || a.id.localeCompare(b.id)
     ),
 });
 


### PR DESCRIPTION
## Summary
- return a valid zero-equivalent ordering path for equal game dates and player totals
- sort games by newest creation date first
- sort players by highest grand total first
- use entity IDs as deterministic tie-breakers
- add regression coverage proving insertion order cannot reshuffle ties

## Validation
- npm run lint
- npm run test -- --runInBand --no-watchman
- 41 suites passed, 402 tests passed