### PR TITLE
Make analytics failures non-blocking

### DIFF
--- a/redux/GamesSlice.ts
+++ b/redux/GamesSlice.ts
@@ -175,7 +175,7 @@ export const asyncRematchGame = createAsyncThunk(
 
         dispatch(setCurrentGameId(newGameId));
 
-        await logEvent('rematch_game', {
+        void logEvent('rematch_game', {
             game_id: game.id,
         });
 
@@ -249,7 +249,7 @@ export const asyncCreateGame = createAsyncThunk(
         dispatch(setCurrentGameId(newGameId));
         dispatch(incrementRollingGameCounter());
 
-        await logEvent('new_game', {
+        void logEvent('new_game', {
             game_count: gameCount,
             player_count: playerCount,
         });

--- a/src/Analytics.test.ts
+++ b/src/Analytics.test.ts
@@ -1,6 +1,11 @@
-import { getAnalytics, logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
+import {
+  getAnalytics,
+  logEvent as firebaseLogEvent,
+  logScreenView as firebaseLogScreenView,
+  setUserProperty as firebaseSetUserProperty,
+} from '@react-native-firebase/analytics';
 
-import { logEvent } from './Analytics';
+import { logEvent, logScreenView, setUserProperty } from './Analytics';
 import logger from './Logger';
 
 // The wrapper's runtime behavior (sanitization, logging) is event-agnostic, so these
@@ -14,12 +19,15 @@ jest.mock('@react-native-firebase/analytics');
 // Mock Logger
 jest.mock('./Logger', () => ({
   info: jest.fn(),
+  error: jest.fn(),
 }));
 
 describe('Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (firebaseLogEvent as jest.Mock).mockResolvedValue(undefined);
+    (firebaseLogScreenView as jest.Mock).mockResolvedValue(undefined);
+    (firebaseSetUserProperty as jest.Mock).mockResolvedValue(undefined);
   });
 
   describe('logEvent', () => {
@@ -68,11 +76,17 @@ describe('Analytics', () => {
       expect(firebaseLogEvent).toHaveBeenCalledWith(expect.anything(), eventName, {});
     });
 
-    it('should propagate Firebase Analytics errors', async () => {
+    it('should absorb and report Firebase Analytics errors', async () => {
       const error = new Error('Firebase error');
       (firebaseLogEvent as jest.Mock).mockRejectedValue(error);
 
-      await expect(log('error_event')).rejects.toThrow('Firebase error');
+      await expect(log('error_event')).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        'ANALYTICS_ERROR',
+        'event',
+        'error_event',
+        error
+      );
     });
 
     it('should strip null and undefined parameter values', async () => {
@@ -97,5 +111,31 @@ describe('Analytics', () => {
         objectParam: { nested: 'value' },
       });
     });
+  });
+
+  it('absorbs screen-view failures', async () => {
+    const error = new Error('Screen view failed');
+    (firebaseLogScreenView as jest.Mock).mockRejectedValue(error);
+
+    await expect(logScreenView('Game')).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      'ANALYTICS_ERROR',
+      'screen_view',
+      'Game',
+      error
+    );
+  });
+
+  it('absorbs user-property failures', async () => {
+    const error = new Error('User property failed');
+    (firebaseSetUserProperty as jest.Mock).mockRejectedValue(error);
+
+    await expect(setUserProperty('color_scheme', 'dark')).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      'ANALYTICS_ERROR',
+      'user_property',
+      'color_scheme',
+      error
+    );
   });
 });

--- a/src/Analytics.ts
+++ b/src/Analytics.ts
@@ -1,4 +1,9 @@
-import { getAnalytics, logEvent as firebaseLogEvent, setUserProperty as firebaseSetUserProperty } from '@react-native-firebase/analytics';
+import {
+    getAnalytics,
+    logEvent as firebaseLogEvent,
+    logScreenView as firebaseLogScreenView,
+    setUserProperty as firebaseSetUserProperty,
+} from '@react-native-firebase/analytics';
 
 import type { AnalyticsEventParams, AnalyticsUserProperty } from './AnalyticsEvents';
 import logger from './Logger';
@@ -22,8 +27,6 @@ export const logEvent = async <K extends keyof AnalyticsEventParams>(
     eventName: K,
     params?: AnalyticsEventParams[K],
 ): Promise<void> => {
-    const analytics = getAnalytics();
-
     const sanitized = Object.fromEntries(
         Object.entries({ ...params }).filter(
             ([, v]) => v != null && v !== undefined,
@@ -38,8 +41,22 @@ export const logEvent = async <K extends keyof AnalyticsEventParams>(
         '\x1b[0m' // Reset the color
     );
 
-    // Log the event to Firebase Analytics
-    await firebaseLogEvent(analytics, eventName, sanitized);
+    try {
+        await firebaseLogEvent(getAnalytics(), eventName, sanitized);
+    } catch (error) {
+        logger.error('ANALYTICS_ERROR', 'event', eventName, error);
+    }
+};
+
+export const logScreenView = async (screenName: string): Promise<void> => {
+    try {
+        await firebaseLogScreenView(getAnalytics(), {
+            screen_name: screenName,
+            screen_class: screenName,
+        });
+    } catch (error) {
+        logger.error('ANALYTICS_ERROR', 'screen_view', screenName, error);
+    }
 };
 
 /**
@@ -51,8 +68,6 @@ export const setUserProperty = async (
     name: AnalyticsUserProperty,
     value: string | null,
 ): Promise<void> => {
-    const analytics = getAnalytics();
-
     logger.info(
         '\x1b[35m', // magenta
         'USER_PROPERTY',
@@ -61,5 +76,9 @@ export const setUserProperty = async (
         '\x1b[0m'
     );
 
-    await firebaseSetUserProperty(analytics, name, value);
+    try {
+        await firebaseSetUserProperty(getAnalytics(), name, value);
+    } catch (error) {
+        logger.error('ANALYTICS_ERROR', 'user_property', name, error);
+    }
 };

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,11 +1,11 @@
 import React, { useRef, useState } from 'react';
 
-import { getAnalytics, logScreenView } from '@react-native-firebase/analytics';
 import { DarkTheme, DefaultTheme, NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Platform, View } from 'react-native';
 
 import { useAppSelector } from '../redux/hooks';
+import { logScreenView } from '../src/Analytics';
 import AppSettingsButton from '../src/components/Buttons/AppSettingsButton';
 import GameOptionsButton from '../src/components/Buttons/GameOptionsButton';
 import RoundHeaderTitle from '../src/components/Headers/RoundHeaderTitle';
@@ -71,7 +71,7 @@ export const Navigation = () => {
         // firebase.json. Fire-and-forget — never block navigation on analytics.
         if (routeName && routeName !== loggedRouteNameRef.current) {
             loggedRouteNameRef.current = routeName;
-            logScreenView(getAnalytics(), { screen_name: routeName, screen_class: routeName });
+            void logScreenView(routeName);
         }
     };
 

--- a/src/components/Buttons/AppSettingsButton.tsx
+++ b/src/components/Buttons/AppSettingsButton.tsx
@@ -21,9 +21,9 @@ const AppSettingsButton: React.FunctionComponent = () => {
     );
 
     return (
-        <HeaderButton accessibilityLabel='App Settings' onPress={async () => {
+        <HeaderButton accessibilityLabel='App Settings' onPress={() => {
             navigation.navigate('AppSettings');
-            await logEvent('app_info');
+            void logEvent('app_info');
         }}>
             <View testID='app-settings-button'>
                 <Icon name="gear"

--- a/src/components/Buttons/BackButton.tsx
+++ b/src/components/Buttons/BackButton.tsx
@@ -16,9 +16,9 @@ interface Props {
 const BackButton: React.FunctionComponent<Props> = ({ navigation }) => {
     const theme = useTheme();
     return (
-        <HeaderButton accessibilityLabel='Home' onPress={async () => {
+        <HeaderButton accessibilityLabel='Home' onPress={() => {
             navigation.goBack();
-            await logEvent('navigate_home');
+            void logEvent('navigate_home');
         }}>
             <Icon name="bars"
                 type="font-awesome-5"

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -76,11 +76,11 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
     /**
      * Choose Game and navigate to GameScreen
      */
-    const chooseGameHandler = async () => {
+    const chooseGameHandler = () => {
         setCurrentGameCallback();
         navigation.navigate('Game');
 
-        await logEvent('select_game', {
+        void logEvent('select_game', {
             list_index: index,
             game_id: gameId,
             player_count: playerIds.length,

--- a/src/components/PlayerListItem.tsx
+++ b/src/components/PlayerListItem.tsx
@@ -60,10 +60,10 @@ const PlayerListItem: React.FunctionComponent<Props> = ({
         );
     };
 
-    const deleteHandler = async () => {
+    const deleteHandler = () => {
         removePlayerHandler();
 
-        await logEvent('remove_player', {
+        void logEvent('remove_player', {
             game_id: currentGameId,
             player_index: index,
         });

--- a/src/components/PopupMenu/AbstractPopupMenu.tsx
+++ b/src/components/PopupMenu/AbstractPopupMenu.tsx
@@ -43,11 +43,11 @@ const AbstractPopupMenu: React.FC<Props> = (props) => {
     /**
      * Share Game
      */
-    const shareGameHandler = async () => {
+    const shareGameHandler = () => {
         props.setCurrentGameCallback();
         props.navigation.navigate('Share');
 
-        await logEvent('menu_share', {
+        void logEvent('menu_share', {
             round_count: roundCount,
             player_count: playerIds.length,
         });
@@ -56,11 +56,11 @@ const AbstractPopupMenu: React.FC<Props> = (props) => {
     /**
      * Edit Game
      */
-    const editGameHandler = async () => {
+    const editGameHandler = () => {
         props.setCurrentGameCallback();
         props.navigation.navigate('EditGame', { source: 'list_screen' });
 
-        await logEvent('menu_edit', {
+        void logEvent('menu_edit', {
             round_count: roundCount,
             player_count: playerIds.length,
         });
@@ -82,7 +82,7 @@ const AbstractPopupMenu: React.FC<Props> = (props) => {
     /**
      * Delete Game
      */
-    const deleteGameHandler = async () => {
+    const deleteGameHandler = () => {
         Alert.alert(
             'Delete Game',
             `Are you sure you want to delete ${gameTitle}?`,
@@ -102,7 +102,7 @@ const AbstractPopupMenu: React.FC<Props> = (props) => {
             { cancelable: false },
         );
 
-        await logEvent('delete_game', {
+        void logEvent('delete_game', {
             list_index: props.index,
             round_count: roundCount,
             player_count: playerIds.length,

--- a/src/components/ScoreLog/RoundScoreColumn.tsx
+++ b/src/components/ScoreLog/RoundScoreColumn.tsx
@@ -31,7 +31,7 @@ const RoundScoreColumn: React.FunctionComponent<Props> = ({
     const sortSelector = sortSelectors[sortKey || SortSelectorKey.ByIndex];
     const sortedPlayerIds = useAppSelector(sortSelector);
 
-    const onPressHandler = useCallback(async () => {
+    const onPressHandler = useCallback(() => {
         if (disabled || !currentGameId) return;
 
         // Read the round we're leaving before we change it (callback has stable deps).
@@ -42,7 +42,7 @@ const RoundScoreColumn: React.FunctionComponent<Props> = ({
                 roundCurrent: round,
             }
         }));
-        await logEvent('round_change', {
+        void logEvent('round_change', {
             game_id: currentGameId,
             source: 'direct select',
             from_round: fromRound,

--- a/src/hooks/useAnalyticsUserProperties.ts
+++ b/src/hooks/useAnalyticsUserProperties.ts
@@ -16,8 +16,8 @@ export const useAnalyticsUserProperties = () => {
     const playerIndex = useAppSelector(state => state.settings.showPlayerIndex);
     const colorScheme = useAppSelector(state => state.settings.colorScheme);
 
-    useEffect(() => { setUserProperty('keep_screen_awake', String(keepScreenAwake)); }, [keepScreenAwake]);
-    useEffect(() => { setUserProperty('point_particles', String(pointParticles)); }, [pointParticles]);
-    useEffect(() => { setUserProperty('player_index', String(playerIndex)); }, [playerIndex]);
-    useEffect(() => { setUserProperty('color_scheme', colorScheme); }, [colorScheme]);
+    useEffect(() => { void setUserProperty('keep_screen_awake', String(keepScreenAwake)); }, [keepScreenAwake]);
+    useEffect(() => { void setUserProperty('point_particles', String(pointParticles)); }, [pointParticles]);
+    useEffect(() => { void setUserProperty('player_index', String(playerIndex)); }, [playerIndex]);
+    useEffect(() => { void setUserProperty('color_scheme', colorScheme); }, [colorScheme]);
 };

--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -146,13 +146,13 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         await exportBackup();
     };
 
-    const alertWithVersion = async () => {
+    const alertWithVersion = () => {
         Alert.alert('ScorePad with Rounds\n' +
             `v${appVersion} (${buildNumber})\n` +
             `${Platform.OS} ${Platform.Version}\n` +
             (process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS)
         );
-        await logEvent('view_version');
+        void logEvent('view_version');
     };
 
     return (

--- a/src/screens/EditGameScreen.tsx
+++ b/src/screens/EditGameScreen.tsx
@@ -45,8 +45,8 @@ const EditGameScreen: React.FunctionComponent<Props> = ({ navigation, route }) =
     useLayoutEffect(() => {
         navigation.setOptions({
             headerRight: () => (
-                <HeaderButton accessibilityLabel='Save Game' onPress={async () => {
-                    await logEvent('save_game', {
+                <HeaderButton accessibilityLabel='Save Game' onPress={() => {
+                    void logEvent('save_game', {
                         source: route?.params?.source,
                         game_id: currentGame?.id,
                         palette: currentGame?.palette,
@@ -68,13 +68,13 @@ const EditGameScreen: React.FunctionComponent<Props> = ({ navigation, route }) =
     if (typeof currentGameId == 'undefined') return null;
     if (typeof playerIds == 'undefined') return null;
 
-    const addPlayerHandler = async () => {
+    const addPlayerHandler = () => {
         dispatch(addPlayer({
             gameId: currentGameId,
             playerName: `Player ${playerIds.length + 1}`,
         }));
 
-        await logEvent('add_player', {
+        void logEvent('add_player', {
             game_id: currentGameId,
             player_count: playerIds.length + 1,
         });

--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -54,10 +54,10 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     useLayoutEffect(() => {
         navigation.setOptions({
             headerLeft: ({ tintColor }) => (
-                <HeaderButton accessibilityLabel='EditPlayerBack' onPress={async () => {
+                <HeaderButton accessibilityLabel='EditPlayerBack' onPress={() => {
                     dismissInput();
                     navigation.goBack();
-                    await logEvent('edit_player_back');
+                    void logEvent('edit_player_back');
                 }}>
                     <Text style={{ color: tintColor ?? theme.tint, fontSize: 20 }}>Back</Text>
                 </HeaderButton>

--- a/src/screens/ShareScreen.tsx
+++ b/src/screens/ShareScreen.tsx
@@ -52,7 +52,7 @@ const ShareScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                 UTI: 'image/png',
             });
 
-            await logEvent('share_image');
+            void logEvent('share_image');
         } catch (error) {
             console.error('Failed to capture or share image:', error);
         }


### PR DESCRIPTION
## Summary
- contain event, screen-view, and user-property failures inside the analytics boundary
- report analytics failures to the local logger without rejecting callers
- route manual screen tracking through the shared safe wrapper
- remove analytics awaits from navigation, scoring, game creation, and editing paths
- mark fire-and-forget telemetry calls explicitly
- add coverage for all three Firebase failure modes

## Validation
- npm run lint
- npm run test -- --runInBand --no-watchman
- 41 suites passed, 402 tests passed