### PR TITLE
Replace deprecated analytics screen helper

### DIFF
--- a/src/Analytics.test.ts
+++ b/src/Analytics.test.ts
@@ -1,7 +1,6 @@
 import {
   getAnalytics,
   logEvent as firebaseLogEvent,
-  logScreenView as firebaseLogScreenView,
   setUserProperty as firebaseSetUserProperty,
 } from '@react-native-firebase/analytics';
 
@@ -26,7 +25,6 @@ describe('Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (firebaseLogEvent as jest.Mock).mockResolvedValue(undefined);
-    (firebaseLogScreenView as jest.Mock).mockResolvedValue(undefined);
     (firebaseSetUserProperty as jest.Mock).mockResolvedValue(undefined);
   });
 
@@ -115,7 +113,7 @@ describe('Analytics', () => {
 
   it('absorbs screen-view failures', async () => {
     const error = new Error('Screen view failed');
-    (firebaseLogScreenView as jest.Mock).mockRejectedValue(error);
+    (firebaseLogEvent as jest.Mock).mockRejectedValue(error);
 
     await expect(logScreenView('Game')).resolves.toBeUndefined();
     expect(logger.error).toHaveBeenCalledWith(

--- a/src/Analytics.ts
+++ b/src/Analytics.ts
@@ -1,7 +1,6 @@
 import {
     getAnalytics,
     logEvent as firebaseLogEvent,
-    logScreenView as firebaseLogScreenView,
     setUserProperty as firebaseSetUserProperty,
 } from '@react-native-firebase/analytics';
 
@@ -50,7 +49,7 @@ export const logEvent = async <K extends keyof AnalyticsEventParams>(
 
 export const logScreenView = async (screenName: string): Promise<void> => {
     try {
-        await firebaseLogScreenView(getAnalytics(), {
+        await firebaseLogEvent(getAnalytics(), 'screen_view', {
             screen_name: screenName,
             screen_class: screenName,
         });

--- a/src/Navigation.test.tsx
+++ b/src/Navigation.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { logScreenView } from '@react-native-firebase/analytics';
+import { logEvent as firebaseLogEvent } from '@react-native-firebase/analytics';
 import { configureStore } from '@reduxjs/toolkit';
 import { act, render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
@@ -168,7 +168,7 @@ describe('Navigation', () => {
     beforeEach(() => {
         mockActiveRouteName = 'List';
         mockNavigationContainerProps = undefined;
-        (logScreenView as jest.Mock).mockClear();
+        (firebaseLogEvent as jest.Mock).mockClear();
         Object.keys(mockScreenListeners).forEach((key) => {
             delete mockScreenListeners[key];
         });
@@ -264,21 +264,23 @@ describe('Navigation', () => {
             mockNavigationContainerProps?.onReady?.();
         });
 
-        expect((logScreenView as jest.Mock)).toHaveBeenCalledWith(
+        expect((firebaseLogEvent as jest.Mock)).toHaveBeenCalledWith(
             expect.anything(),
+            'screen_view',
             { screen_name: 'List', screen_class: 'List' },
         );
 
-        (logScreenView as jest.Mock).mockClear();
+        (firebaseLogEvent as jest.Mock).mockClear();
         setActiveRoute('Game');
-        expect((logScreenView as jest.Mock)).toHaveBeenCalledWith(
+        expect((firebaseLogEvent as jest.Mock)).toHaveBeenCalledWith(
             expect.anything(),
+            'screen_view',
             { screen_name: 'Game', screen_class: 'Game' },
         );
 
         // Same route fires onStateChange again — should not re-log.
-        (logScreenView as jest.Mock).mockClear();
+        (firebaseLogEvent as jest.Mock).mockClear();
         setActiveRoute('Game');
-        expect((logScreenView as jest.Mock)).not.toHaveBeenCalled();
+        expect((firebaseLogEvent as jest.Mock)).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- replace React Native Firebase logScreenView(), which is deprecated in v24
- emit the supported screen_view event through modular logEvent()
- preserve screen_name and screen_class parameters
- update analytics and navigation tests to assert the replacement event payload

## Validation
- npm run lint
- npm run test -- --runInBand --no-watchman
- 42 suites passed, 414 tests passed