### PR TITLE
chore: bump version to 3.0.3

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -72,7 +72,7 @@ switch (variant) {
 export default {
   name: 'ScorePad with Rounds',
   slug: 'scorepad',
-  version: '3.0.2',
+  version: '3.0.3',
   orientation: 'default',
   icon: icon,
   assetBundlePatterns: ['assets/*'],


### PR DESCRIPTION
Bumps the app's marketing version **3.0.2 → 3.0.3** in [app.config.js](app.config.js).

## Note on build numbers
Build numbers (iOS `buildNumber` / Android `versionCode`) are managed by EAS remotely — `eas.json` sets `appVersionSource: "remote"` and the `production` profile has `autoIncrement: true`. So the local `versionCode: 88` is vestigial and intentionally left untouched; EAS will assign/increment the build number at build time.

One-line change; no code/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)