### PR TITLE
fix: restore App Store review prompts, lost in the v3.0.0 refactor

### DIFF
--- a/src/AnalyticsEvents.ts
+++ b/src/AnalyticsEvents.ts
@@ -113,6 +113,20 @@ export interface AnalyticsEventParams {
     backup_restore: Record<string, never>;
     /** User exported a backup of their data. */
     backup_export: Record<string, never>;
+
+    // ── Store review ────────────────────────────────────────────────────────
+    /**
+     * The native App Store review prompt was requested. Note this means we asked
+     * the OS, not that the user saw a dialog — iOS silently declines when it has
+     * shown too many prompts recently, and never tells us.
+     */
+    review_prompt: { game_count: number; days_since_last?: number };
+    /**
+     * We passed our own eligibility gates but no prompt was requested. Only
+     * logged for these outcomes — the ordinary "not eligible yet" case is not
+     * logged, since it would fire on nearly every navigation home.
+     */
+    review_prompt_skipped: { reason: 'unavailable' | 'error'; game_count: number };
 }
 
 export type AnalyticsEventName = keyof AnalyticsEventParams;

--- a/src/components/Buttons/BackButton.tsx
+++ b/src/components/Buttons/BackButton.tsx
@@ -5,6 +5,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Icon } from 'react-native-elements/dist/icons/Icon';
 
 import { logEvent } from '../../Analytics';
+import { useStoreReviewPrompt } from '../../hooks/useStoreReviewPrompt';
 import { useTheme } from '../../theme';
 
 import HeaderButton from './HeaderButton';
@@ -15,10 +16,13 @@ interface Props {
 
 const BackButton: React.FunctionComponent<Props> = ({ navigation }) => {
     const theme = useTheme();
+    const promptForReview = useStoreReviewPrompt();
     return (
         <HeaderButton accessibilityLabel='Home' onPress={() => {
             navigation.goBack();
             void logEvent('navigate_home');
+            // Leaving a game they've been playing is the calmest moment to ask.
+            void promptForReview();
         }}>
             <Icon name="bars"
                 type="font-awesome-5"

--- a/src/hooks/useStoreReviewPrompt.test.tsx
+++ b/src/hooks/useStoreReviewPrompt.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react-native';
+import * as StoreReview from 'expo-store-review';
+import { Provider } from 'react-redux';
+
+import gamesReducer from '../../redux/GamesSlice';
+import playersReducer from '../../redux/PlayersSlice';
+import settingsReducer from '../../redux/SettingsSlice';
+import { logEvent } from '../Analytics';
+
+import {
+    MIN_GAMES_FOR_REVIEW,
+    REVIEW_PROMPT_INTERVAL_DAYS,
+    shouldPromptForReview,
+    useStoreReviewPrompt,
+} from './useStoreReviewPrompt';
+
+jest.mock('../Analytics');
+jest.mock('expo-store-review', () => ({
+    isAvailableAsync: jest.fn(),
+    requestReview: jest.fn(),
+}));
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const NOW = 1_700_000_000_000;
+const daysAgo = (days: number) => NOW - days * MS_PER_DAY;
+
+describe('shouldPromptForReview', () => {
+    const eligible = { gameCount: 5, roundCurrent: 3, lastPrompt: 0, now: NOW };
+
+    it('prompts a user who qualifies and has never been prompted', () => {
+        expect(shouldPromptForReview(eligible)).toBe(true);
+    });
+
+    it('does not prompt below the game threshold', () => {
+        expect(shouldPromptForReview({ ...eligible, gameCount: MIN_GAMES_FOR_REVIEW - 1 })).toBe(false);
+    });
+
+    it('prompts exactly at the game threshold', () => {
+        expect(shouldPromptForReview({ ...eligible, gameCount: MIN_GAMES_FOR_REVIEW })).toBe(true);
+    });
+
+    it('does not prompt a user who has not scored in the current game', () => {
+        expect(shouldPromptForReview({ ...eligible, roundCurrent: 0 })).toBe(false);
+    });
+
+    it('does not prompt within the interval', () => {
+        const lastPrompt = daysAgo(REVIEW_PROMPT_INTERVAL_DAYS - 1);
+        expect(shouldPromptForReview({ ...eligible, lastPrompt })).toBe(false);
+    });
+
+    it('prompts once the full interval has elapsed', () => {
+        const lastPrompt = daysAgo(REVIEW_PROMPT_INTERVAL_DAYS);
+        expect(shouldPromptForReview({ ...eligible, lastPrompt })).toBe(true);
+    });
+});
+
+interface StoreOpts {
+    gameCount?: number;
+    roundCurrent?: number;
+    lastStoreReviewPrompt?: number;
+}
+
+const createStore = (opts: StoreOpts = {}) => {
+    const gameCount = opts.gameCount ?? 5;
+    const ids = Array.from({ length: gameCount }, (_, i) => `game-${i}`);
+    const entities = Object.fromEntries(ids.map(id => [id, {
+        id, playerIds: ['p1'], dateCreated: 0, roundCurrent: opts.roundCurrent ?? 3, roundTotal: 4, locked: false,
+    }]));
+
+    return configureStore({
+        reducer: { settings: settingsReducer, games: gamesReducer, players: playersReducer },
+        preloadedState: {
+            settings: {
+                currentGameId: ids[0],
+                lastStoreReviewPrompt: opts.lastStoreReviewPrompt ?? 0,
+            },
+            games: { entities, ids },
+            players: { entities: { p1: { id: 'p1', playerName: 'P1', scores: [0] } }, ids: ['p1'] },
+        } as Parameters<typeof configureStore>[0]['preloadedState'],
+    });
+};
+
+const renderPrompt = (store: ReturnType<typeof createStore>) => renderHook(
+    () => useStoreReviewPrompt(),
+    {
+        wrapper: ({ children }: { children: React.ReactNode }) =>
+            React.createElement(Provider, { store, children }),
+    },
+);
+
+describe('useStoreReviewPrompt', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(Date, 'now').mockReturnValue(NOW);
+        (StoreReview.isAvailableAsync as jest.Mock).mockResolvedValue(true);
+        (StoreReview.requestReview as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('requests a review, records the timestamp, and logs it', async () => {
+        const store = createStore();
+        const { result } = renderPrompt(store);
+
+        await result.current();
+
+        expect(StoreReview.requestReview).toHaveBeenCalled();
+        expect(store.getState().settings.lastStoreReviewPrompt).toBe(NOW);
+        expect(logEvent).toHaveBeenCalledWith('review_prompt', { game_count: 5, days_since_last: undefined });
+    });
+
+    it('reports how long it had been since the previous prompt', async () => {
+        const store = createStore({ lastStoreReviewPrompt: daysAgo(120) });
+        const { result } = renderPrompt(store);
+
+        await result.current();
+
+        expect(logEvent).toHaveBeenCalledWith('review_prompt', { game_count: 5, days_since_last: 120 });
+    });
+
+    it('does nothing when the user is not eligible', async () => {
+        const store = createStore({ gameCount: 2 });
+        const { result } = renderPrompt(store);
+
+        await result.current();
+
+        expect(StoreReview.isAvailableAsync).not.toHaveBeenCalled();
+        expect(StoreReview.requestReview).not.toHaveBeenCalled();
+        expect(logEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not consume the interval when the store prompt is unavailable', async () => {
+        (StoreReview.isAvailableAsync as jest.Mock).mockResolvedValue(false);
+        const store = createStore();
+        const { result } = renderPrompt(store);
+
+        await result.current();
+
+        expect(StoreReview.requestReview).not.toHaveBeenCalled();
+        expect(store.getState().settings.lastStoreReviewPrompt).toBe(0);
+        expect(logEvent).toHaveBeenCalledWith('review_prompt_skipped', { reason: 'unavailable', game_count: 5 });
+    });
+
+    it('does not consume the interval when the native call throws', async () => {
+        (StoreReview.requestReview as jest.Mock).mockRejectedValue(new Error('nope'));
+        const store = createStore();
+        const { result } = renderPrompt(store);
+
+        await result.current();
+
+        expect(store.getState().settings.lastStoreReviewPrompt).toBe(0);
+        expect(logEvent).toHaveBeenCalledWith('review_prompt_skipped', { reason: 'error', game_count: 5 });
+    });
+});

--- a/src/hooks/useStoreReviewPrompt.ts
+++ b/src/hooks/useStoreReviewPrompt.ts
@@ -1,0 +1,90 @@
+import { useCallback } from 'react';
+
+import * as StoreReview from 'expo-store-review';
+
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { selectCurrentGame, selectLastStoreReviewPrompt } from '../../redux/selectors';
+import { setLastStoreReviewPrompt } from '../../redux/SettingsSlice';
+import { logEvent } from '../Analytics';
+import logger from '../Logger';
+
+/** Minimum games created before we'll ever ask for a review. */
+export const MIN_GAMES_FOR_REVIEW = 3;
+/** Minimum days between prompts. Apple throttles independently; this is our own floor. */
+export const REVIEW_PROMPT_INTERVAL_DAYS = 90;
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export interface ReviewEligibility {
+    gameCount: number;
+    /** Current round of the active game; 0 means the user hasn't scored anything yet. */
+    roundCurrent: number;
+    /** Epoch ms of the last prompt. 0 = never prompted. */
+    lastPrompt: number;
+    now: number;
+}
+
+/**
+ * Pure gate for the review prompt. Kept separate from the hook so the rules are
+ * testable without a store, a renderer, or the native module.
+ */
+export const shouldPromptForReview = (
+    { gameCount, roundCurrent, lastPrompt, now }: ReviewEligibility,
+): boolean => {
+    if (gameCount < MIN_GAMES_FOR_REVIEW) return false;
+    // Don't ask someone who opened a game but never scored in it.
+    if (roundCurrent < 1) return false;
+
+    const daysSinceLastPrompt = (now - lastPrompt) / MS_PER_DAY;
+    return daysSinceLastPrompt >= REVIEW_PROMPT_INTERVAL_DAYS;
+};
+
+/**
+ * Returns a callback that asks for an App Store review when the user looks
+ * happy enough to ask: they've made a few games and actually played the current
+ * one, and we haven't asked in the last 90 days.
+ *
+ * This lives in a hook rather than inside a button because the previous
+ * implementation was inlined in HomeButton and was deleted along with that
+ * component during the v3.0.0 navigation refactor, silently disabling review
+ * prompts for three months.
+ *
+ * The timestamp is recorded only once the native prompt is actually requested —
+ * recording it before the availability check would burn the full 90-day window
+ * on a user who was never shown anything.
+ */
+export function useStoreReviewPrompt(): () => Promise<void> {
+    const gameCount = useAppSelector(state => state.games.ids.length);
+    const roundCurrent = useAppSelector(state => selectCurrentGame(state)?.roundCurrent ?? 0);
+    const lastPrompt = useAppSelector(selectLastStoreReviewPrompt);
+    const dispatch = useAppDispatch();
+
+    return useCallback(async () => {
+        const now = Date.now();
+
+        if (!shouldPromptForReview({ gameCount, roundCurrent, lastPrompt, now })) return;
+
+        try {
+            // iOS may decline to show anything (its own rate limit); Android
+            // needs Play Services. Either way we learn nothing was shown.
+            const isAvailable = await StoreReview.isAvailableAsync();
+            if (!isAvailable) {
+                void logEvent('review_prompt_skipped', { reason: 'unavailable', game_count: gameCount });
+                return;
+            }
+
+            await StoreReview.requestReview();
+
+            dispatch(setLastStoreReviewPrompt(now));
+            void logEvent('review_prompt', {
+                game_count: gameCount,
+                days_since_last: lastPrompt === 0
+                    ? undefined
+                    : Math.round((now - lastPrompt) / MS_PER_DAY),
+            });
+        } catch (error) {
+            logger.error('STORE_REVIEW_ERROR', error);
+            void logEvent('review_prompt_skipped', { reason: 'error', game_count: gameCount });
+        }
+    }, [gameCount, roundCurrent, lastPrompt, dispatch]);
+}


### PR DESCRIPTION
The review prompt added in c4c693e lived inline in HomeButton.tsx. The
v3.0.0 navigation refactor (8e7845d) deleted that component and replaced
it with BackButton.tsx, which kept the analytics call but dropped the
storePrompt() call. No user has been prompted for a review since v3.0.0.
The redux state (lastStoreReviewPrompt), its persistence, and the
expo-store-review dependency were all left behind as dead scaffolding.

Restore the behavior in src/hooks/useStoreReviewPrompt.ts so it is no
longer attached to the lifetime of a particular button, with the gating
rules extracted into a pure, tested shouldPromptForReview().

Changes from the original implementation:
- Interval is 90 days (was 180).
- The timestamp is recorded only after the prompt is actually requested.
  Previously it was written before the availability check, so a user who
  was never shown anything still burned the full interval.
- Native failures are caught rather than rejecting into the press handler.
- Adds review_prompt / review_prompt_skipped to the analytics catalog.
  The original logged nothing, which is why this regression went
  unnoticed for three months. The routine "not eligible yet" case is
  deliberately not logged, as it would fire on nearly every navigation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H2g7SUrvu9PmLkuB3t3LCn