### PR TITLE
Bump app version to 3.0.4

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -72,7 +72,7 @@ switch (variant) {
 export default {
   name: 'ScorePad with Rounds',
   slug: 'scorepad',
-  version: '3.0.3',
+  version: '3.0.4',
   orientation: 'default',
   icon: icon,
   assetBundlePatterns: ['assets/*'],


### PR DESCRIPTION
## Summary
- bump the Expo app version from 3.0.3 to 3.0.4 for the next production submission

## Validation
- `npx expo config --type public`
- `npm run lint`
- `git diff --check`
- `npx expo prebuild --clean`