### PR TITLE
fix: move the review prompt onto a screen that actually mounts

### DIFF
--- a/src/components/Buttons/BackButton.tsx
+++ b/src/components/Buttons/BackButton.tsx
@@ -5,7 +5,6 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Icon } from 'react-native-elements/dist/icons/Icon';
 
 import { logEvent } from '../../Analytics';
-import { useStoreReviewPrompt } from '../../hooks/useStoreReviewPrompt';
 import { useTheme } from '../../theme';
 
 import HeaderButton from './HeaderButton';
@@ -16,13 +15,10 @@ interface Props {
 
 const BackButton: React.FunctionComponent<Props> = ({ navigation }) => {
     const theme = useTheme();
-    const promptForReview = useStoreReviewPrompt();
     return (
         <HeaderButton accessibilityLabel='Home' onPress={() => {
             navigation.goBack();
             void logEvent('navigate_home');
-            // Leaving a game they've been playing is the calmest moment to ask.
-            void promptForReview();
         }}>
             <Icon name="bars"
                 type="font-awesome-5"

--- a/src/screens/ListScreen.test.tsx
+++ b/src/screens/ListScreen.test.tsx
@@ -19,6 +19,23 @@ jest.mock('@react-navigation/elements', () => ({
     useHeaderHeight: () => 0,
 }));
 
+// Focus effects run outside a NavigationContainer here: invoke the callback
+// once, standing in for the initial focus when the app opens on the list.
+const focusCallbacks: (() => void)[] = [];
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useFocusEffect: (callback: () => void) => {
+        const { useEffect } = jest.requireActual('react');
+        focusCallbacks.push(callback);
+        useEffect(() => callback(), [callback]);
+    },
+}));
+
+jest.mock('../hooks/useStoreReviewPrompt', () => ({
+    useStoreReviewPrompt: () => mockPromptForReview,
+}));
+const mockPromptForReview = jest.fn();
+
 jest.mock('expo-blur', () => ({
     BlurView: ({ children, style }: { children: React.ReactNode; style: object }) => {
         const { View } = jest.requireActual('react-native');
@@ -401,5 +418,40 @@ describe('ListScreen', () => {
                 right: 12 + FAB_EDGE_MARGIN,
             })
         );
+    });
+});
+
+describe('ListScreen store review prompt', () => {
+    const renderList = () => {
+        const store = createMockStore({
+            settings: { appOpens: 3, devMenuEnabled: false, installId: 'existing-id', rollingGameCounter: 3 },
+            games: { entities: {}, ids: [] },
+            players: { entities: {}, ids: [] },
+        });
+        return render(
+            <Provider store={store}>
+                <ListScreen navigation={mockNavigation} />
+            </Provider>
+        );
+    };
+
+    beforeEach(() => {
+        focusCallbacks.length = 0;
+        mockPromptForReview.mockClear();
+    });
+
+    // The prompt must hang off a screen that actually mounts. The pre-3.0.4
+    // implementation was attached to BackButton, which the v3.0.0 refactor
+    // stopped rendering, so it could never fire.
+    it('does not prompt on the first focus (app launch)', () => {
+        renderList();
+        expect(mockPromptForReview).not.toHaveBeenCalled();
+    });
+
+    it('prompts when the list is focused again after a game', () => {
+        renderList();
+        expect(focusCallbacks.length).toBeGreaterThan(0);
+        focusCallbacks[focusCallbacks.length - 1]();
+        expect(mockPromptForReview).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -1,7 +1,7 @@
-import React, { memo, useEffect } from 'react';
+import React, { memo, useCallback, useEffect, useRef } from 'react';
 
 import { useHeaderHeight } from '@react-navigation/elements';
-import { ParamListBase } from '@react-navigation/native';
+import { ParamListBase, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import * as Crypto from 'expo-crypto';
 import { Platform, StyleSheet, Text } from 'react-native';
@@ -14,6 +14,7 @@ import { increaseAppOpens, setInstallId, setRollingGameCounter } from '../../red
 import { logEvent } from '../Analytics';
 import FloatingActionButton, { FAB_BOTTOM_MARGIN, FAB_LIST_CLEARANCE, FAB_SIZE } from '../components/FloatingActionButton';
 import GameListItem from '../components/GameListItem';
+import { useStoreReviewPrompt } from '../hooks/useStoreReviewPrompt';
 import { useTheme } from '../theme';
 
 interface Props {
@@ -33,6 +34,22 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     const listHeaderInset = Platform.OS === 'ios' ? headerHeight : 0;
     const insets = useSafeAreaInsets();
     const listBottomInset = insets.bottom + FAB_BOTTOM_MARGIN + FAB_SIZE + FAB_LIST_CLEARANCE;
+
+    // Ask for a review when the user comes back to the list from a game — the
+    // same moment the pre-3.0.0 prompt used, when it hung off the header's home
+    // button. The first focus is the app launching into the list, which is not
+    // that moment, so it is skipped.
+    const promptForReview = useStoreReviewPrompt();
+    const hasFocusedOnce = useRef(false);
+    useFocusEffect(
+        useCallback(() => {
+            if (!hasFocusedOnce.current) {
+                hasFocusedOnce.current = true;
+                return;
+            }
+            void promptForReview();
+        }, [promptForReview]),
+    );
 
     useEffect(() => {
         if (installId === undefined) {


### PR DESCRIPTION
## The problem

The review prompt restored in #711 (shipped in 3.0.4) can never fire.

It was attached to `BackButton.tsx`, which **is not imported anywhere**. The v3.0.0 refactor switched the Game screen to the native-stack back button (`headerBackButtonDisplayMode: 'minimal'`) and left that component orphaned.

BigQuery confirms it — `navigate_home`, the event sharing the same trigger, has **zero events across every 3.x version**, while `game_list` has 321 events on 3.0.3 alone over the same 7 days:

| version | event | events | users |
|---|---|---|---|
| 3.0.4 | `game_list` | 8 | 7 |
| 3.0.3 | `game_list` | 321 | 169 |
| 3.0.3 | `navigate_home` | 0 | 0 |
| 2.5.10 | `review_prompt` | 1 | 1 |

`review_prompt` only appears on 2.5.x binaries — users who never updated. It has been zero on every 3.x release since v3.0.0 in June.

## The fix

Move the prompt to `ListScreen`, which mounts on every return from a game, via `useFocusEffect`. The first focus is skipped so the app opening onto the list isn't mistaken for leaving a game.

The `BackButton` call site is reverted rather than left as a second, dead one.

## Tests

The existing tests covered the gating rules but not whether the trigger was *reachable* — exactly what failed. Added two that assert the prompt does not fire on first focus and does fire on a subsequent one.

427 tests pass; lint and typecheck clean.

## Notes

- JS-only, so this can ship as an EAS update to the production channel rather than waiting on App Review.
- `BackButton.tsx` is now entirely dead, and `navigate_home` is an event that can never fire. Both are left alone here as unrelated to this fix.
- 3.0.4 is at ~7 users so far, so expect thin data until the rollout widens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2g7SUrvu9PmLkuB3t3LCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2g7SUrvu9PmLkuB3t3LCn)_