### PR TITLE
fix(analytics): make dev_menu_enabled reportable as false

### DIFF
--- a/redux/SettingsSlice.ts
+++ b/redux/SettingsSlice.ts
@@ -36,6 +36,9 @@ export const initialState: SettingsState = {
     lastUsedInteractionType: undefined,
     lastStoreReviewPrompt: 0,
     appOpens: 0,
+    // Seeded so the flag is always defined: logEvent strips undefined params,
+    // which meant dev_menu_enabled only ever reached analytics as true.
+    devMenuEnabled: false,
     installId: undefined,
     rollingGameCounter: 0,
     keepScreenAwake: false,

--- a/src/screens/ListScreen.test.tsx
+++ b/src/screens/ListScreen.test.tsx
@@ -455,3 +455,33 @@ describe('ListScreen store review prompt', () => {
         expect(mockPromptForReview).toHaveBeenCalledTimes(1);
     });
 });
+
+describe('ListScreen dev_menu_enabled param', () => {
+    // logEvent strips undefined params, so an unseeded devMenuEnabled meant the
+    // flag reached analytics only when true — 4 of 1543 events in production.
+    it('reports dev_menu_enabled: false rather than omitting it', () => {
+        const store = createMockStore({
+            settings: {
+                appOpens: 1,
+                devMenuEnabled: undefined,
+                installId: 'test-install-id',
+                rollingGameCounter: 0,
+            },
+            games: { entities: {}, ids: [] },
+            players: { entities: {}, ids: [] },
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { logEvent } = require('../Analytics');
+
+        render(
+            <Provider store={store}>
+                <ListScreen navigation={mockNavigation} />
+            </Provider>
+        );
+
+        expect(logEvent).toHaveBeenCalledWith('game_list', expect.objectContaining({
+            dev_menu_enabled: false,
+        }));
+    });
+});

--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -65,7 +65,8 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         logEvent('game_list', {
             game_count: gameIds.length,
             app_opens: appOpens,
-            dev_menu_enabled: devMenuEnabled,
+            // Coerced: a settings backup predating the seeded default restores undefined.
+            dev_menu_enabled: devMenuEnabled ?? false,
             install_id: installId,
             rolling_game_counter: rollingGameCounter,
         });


### PR DESCRIPTION
## The problem

`devMenuEnabled` is optional and absent from `SettingsSlice` `initialState`, so it's `undefined` for everyone who has never toggled it. `logEvent` strips null/undefined params, so the flag reached GA4 **only when true** — 4 of 1543 `game_list` events over 30 days, all value `1`.

The catalog types it as an optional boolean, implying you can segment on false. You can't: it's a presence flag, and "dev menu off" is indistinguishable from "param missing".

## The fix

Seed `devMenuEnabled: false` in `initialState`.

Checked the surrounding state plumbing, as flagged during the audit:
- already in the `store.ts` persist allowlist — no change needed
- `backup.ts` already accepts `undefined || boolean`, so older backups stay valid

Because a legacy backup can still restore `undefined`, the call site coerces with `?? false` so the param is always defined.

## Tests

One added: `dev_menu_enabled: false` is reported rather than omitted when the stored value is `undefined`.

428 tests pass; lint and typecheck clean.

## Note

Touches the same `logEvent('game_list', …)` block as #716, so whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2g7SUrvu9PmLkuB3t3LCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2g7SUrvu9PmLkuB3t3LCn)_