### PR TITLE
fix(dial): cancel the gesture-hint animation when the hint is dismissed

### DIFF
--- a/src/components/Interactions/Dial/DialControl.test.tsx
+++ b/src/components/Interactions/Dial/DialControl.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react-native';
-import { SharedValue } from 'react-native-reanimated';
+import { cancelAnimation, SharedValue } from 'react-native-reanimated';
 
 jest.mock('react-native-reanimated', () => {
     const React = jest.requireActual('react');
@@ -33,6 +33,7 @@ jest.mock('react-native-reanimated', () => {
         withDelay: (_ms: number, v: unknown) => v,
         withSequence: (...vals: unknown[]) => vals[0],
         withRepeat: (v: unknown) => v,
+        cancelAnimation: jest.fn(),
         runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
         Easing: {
             out: () => () => 0,
@@ -108,6 +109,43 @@ describe('getCenterValueFontScale', () => {
 
     it('does not shrink below the minimum scale for very long values', () => {
         expect(getCenterValueFontScale(123456789)).toBe(0.62);
+    });
+});
+
+describe('DialControl — gesture hint animation', () => {
+    // Both hint loops are withRepeat(..., -1): infinite. showHint only gates whether
+    // the arrows render, so without an effect cleanup the loops keep running on the
+    // UI thread for the life of the dial once the hint is dismissed.
+    const cancelAnimationMock = cancelAnimation as unknown as jest.Mock;
+
+    it('does not cancel while the hint is still showing', () => {
+        render(<DialControl {...defaultProps} showHint={true} />);
+        expect(cancelAnimationMock).not.toHaveBeenCalled();
+    });
+
+    it('cancels both hint loops when the hint is dismissed', () => {
+        const { rerender } = render(<DialControl {...defaultProps} showHint={true} />);
+        cancelAnimationMock.mockClear();
+
+        rerender(<DialControl {...defaultProps} showHint={false} />);
+
+        // one for arrowBob, one for arrowOpacity
+        expect(cancelAnimationMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('cancels both hint loops on unmount', () => {
+        const { unmount } = render(<DialControl {...defaultProps} showHint={true} />);
+        cancelAnimationMock.mockClear();
+
+        unmount();
+
+        expect(cancelAnimationMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('starts no hint loop when the hint is never shown', () => {
+        const { unmount } = render(<DialControl {...defaultProps} showHint={false} />);
+        unmount();
+        expect(cancelAnimationMock).not.toHaveBeenCalled();
     });
 });
 

--- a/src/components/Interactions/Dial/DialControl.tsx
+++ b/src/components/Interactions/Dial/DialControl.tsx
@@ -4,6 +4,7 @@ import * as Haptics from 'expo-haptics';
 import { Pressable, StyleSheet, Text, TextInput, TextInputProps, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
+    cancelAnimation,
     Easing,
     runOnJS,
     SharedValue,
@@ -127,7 +128,16 @@ const DialControl: React.FC<Props> = ({
                 withTiming(0.4, { duration: 750, easing: Easing.inOut(Easing.quad) }),
             ), -1, false,
         );
-    }, [showHint]);
+
+        // Both loops repeat forever; without this the arrows keep animating on
+        // the UI thread after the hint is dismissed and nothing reads them.
+        return () => {
+            cancelAnimation(arrowBob);
+            cancelAnimation(arrowOpacity);
+            arrowBob.value = 0;
+            arrowOpacity.value = 0.4;
+        };
+    }, [showHint, arrowBob, arrowOpacity]);
 
     const leftArrowStyle = useAnimatedStyle(() => ({
         opacity: arrowOpacity.value,
@@ -143,12 +153,7 @@ const DialControl: React.FC<Props> = ({
             withTiming(1.15, { duration: 55 }),
             withTiming(1, { duration: 140, easing: Easing.out(Easing.cubic) }),
         );
-    }, []);
-
-    // Cancel any in-progress dial long-press when the menu opens
-    useEffect(() => {
-        if (menuOpen) stopLongPress();
-    }, [menuOpen]);
+    }, [numScale]);
 
     const isSecondaryRef = useRef(isSecondary);
     isSecondaryRef.current = isSecondary;
@@ -168,7 +173,7 @@ const DialControl: React.FC<Props> = ({
     const svLastStep = useSharedValue(0);
     const svDidFlush = useSharedValue(true);
 
-    useEffect(() => { svInc.value = isSecondary ? addendTwo : addendOne; }, [isSecondary, addendOne, addendTwo]);
+    useEffect(() => { svInc.value = isSecondary ? addendTwo : addendOne; }, [isSecondary, addendOne, addendTwo, svInc]);
 
     const lpTimer = useRef<ReturnType<typeof setTimeout>>();
     useEffect(() => () => clearTimeout(lpTimer.current), []);
@@ -197,7 +202,7 @@ const DialControl: React.FC<Props> = ({
             pillScale.value = withTiming(1, { duration: 150 });
             pillOpacity.value = withTiming(1, { duration: 150 });
         }
-    }, [isSecondary]);
+    }, [pillActive, pillOpacity, pillScale]);
 
     const pillStyle = useAnimatedStyle(() => ({
         transform: [{ scale: pillScale.value }],
@@ -231,12 +236,18 @@ const DialControl: React.FC<Props> = ({
                 holdProgress.value = withTiming(0, { duration: 120, easing: Easing.out(Easing.cubic) });
             }
         }, SECONDARY_HOLD_ACTIVATION_MS);
-    }, [onToggleMode]);
+    }, [onToggleMode, holdProgress, svAccDeg, svHasMoved]);
 
     const stopLongPress = useCallback(() => {
         clearTimeout(lpTimer.current);
         holdProgress.value = withTiming(0, { duration: 200, easing: Easing.out(Easing.cubic) });
-    }, []);
+    }, [holdProgress]);
+
+    // Cancel any in-progress dial long-press when the menu opens.
+    // Declared after stopLongPress so the dependency array can reference it.
+    useEffect(() => {
+        if (menuOpen) stopLongPress();
+    }, [menuOpen, stopLongPress]);
 
     const handleBumpFeedback = useCallback(() => {
         if (isSecondaryRef.current) popNumber();


### PR DESCRIPTION
Started as "silence the `exhaustive-deps` warnings in `DialControl`." All seven turned out to be false positives — but chasing them surfaced a real leak.

## The bug

```js
useEffect(() => {
    if (!showHint) return;
    arrowBob.value     = withRepeat(…, -1, false);  // infinite
    arrowOpacity.value = withRepeat(…, -1, false);  // infinite
}, [showHint]);
```

`showHint` only gates whether the arrows **render** (`{showHint && …}`, line 485). When it flips false the arrows unmount, the effect re-runs and hits the early return — and both `withRepeat(…, -1)` loops keep running on the UI thread for the life of the dial, with nothing reading them.

`showHint` is a first-run gesture hint, so this is the *normal* path: once a user dismisses the hint, every mounted dial animates two shared values forever. The pill effect right below already gets this right via its `else` branch.

Fix is an effect cleanup that cancels both loops and restores their initial values.

## The seven warnings

All false positives — `useSharedValue` returns a ref-stable object and `react-hooks/exhaustive-deps` has no way to know that. Adding the deps is behavior-preserving. Three needed more than a mechanical edit:

**`startLongPress`** takes `svHasMoved`, not `svHasMoved.value` as the rule suggested. The object is the stable reference; reading `.value` during render is exactly what Reanimated warns against, and it would make the callback unstable. Passing the object satisfies the rule without that.

**The pill effect** now lists `pillActive` instead of `isSecondary`. Since `pillActive = isSecondary`, the array was already correct — the rule just tracks identifiers, not values. Naming the one the body actually reads fixes the warning and reads better.

**The `menuOpen` effect** moved below `stopLongPress`. It previously sat *above* the declaration, so adding `stopLongPress` to its dependency array would evaluate the array during render and throw a TDZ `ReferenceError`. Moving the effect is what makes the dependency expressible at all.

## Verification

| | before | after |
|---|---|---|
| `npm run lint` | 24 warnings, 0 errors | **17 warnings, 0 errors** |
| `DialControl.tsx` warnings | 7 | **0** |
| `npm test` | 43 suites, 428 tests | **43 suites, 432 tests** |

The 4 new tests cover both paths that end the hint — dismissal and unmount — plus two guards (no cancel while showing, no loop when never shown). **I confirmed the two behavior tests fail without the cleanup** by stripping it and re-running: `2 failed, 18 passed`.

The Reanimated test mock also gains `cancelAnimation`. No existing test rendered `showHint={true}`, which is why the mock never needed it — and why, without this addition, the first test to render the hint would have thrown on an undefined function.

## Notes

- The 17 remaining warnings are all in other files (`ListBoard`, `TileBoard`, `DialOverlay`, `Swipe`, `EditGame`, the `Score*` tiles), untouched here.
- Independent of [#719](https://github.com/wyne/scorepad-react-native/pull/719) — branched from `main`, no overlapping files, either can merge first.
- Not device-tested: the cleanup path is covered by unit tests against the Reanimated mock, but the visual behavior (hint arrows stopping cleanly rather than freezing mid-bob) is worth a look on a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ac1pGiTeqXZq5sBMXiJvYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ac1pGiTeqXZq5sBMXiJvYc)_