### PR TITLE
test: cover the review prompt end to end, screen through to analytics

### DIFF
--- a/src/screens/ListScreen.reviewPrompt.test.tsx
+++ b/src/screens/ListScreen.reviewPrompt.test.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { configureStore } from '@reduxjs/toolkit';
+import { render, waitFor } from '@testing-library/react-native';
+import * as StoreReview from 'expo-store-review';
+import { Provider } from 'react-redux';
+
+import gamesReducer from '../../redux/GamesSlice';
+import playersReducer from '../../redux/PlayersSlice';
+import settingsReducer from '../../redux/SettingsSlice';
+import { logEvent } from '../Analytics';
+
+import ListScreen from './ListScreen';
+
+/**
+ * End-to-end cover for the review prompt: real ListScreen, real
+ * useStoreReviewPrompt, real reducers and selectors. Only the native module and
+ * the analytics transport are stubbed.
+ *
+ * ListScreen.test.tsx mocks the hook and useStoreReviewPrompt.test.tsx mocks the
+ * store, so between them the wiring itself -- the screen actually mounting, the
+ * hook actually reading the store -- was never exercised. That seam is where
+ * this feature has broken twice: the v3.0.0 refactor deleted the component the
+ * prompt hung off, and the v3.0.4 fix reattached it to BackButton, which was
+ * itself no longer rendered. Both times the logic was fine and the wiring was
+ * not, and both times the tests stayed green.
+ */
+
+jest.mock('@react-navigation/elements', () => ({
+    useHeaderHeight: () => 0,
+}));
+
+// Focus effects run outside a NavigationContainer here. The first invocation
+// stands in for the app opening on the list; refocus() is the return from a game.
+const focusCallbacks: (() => void)[] = [];
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useFocusEffect: (callback: () => void) => {
+        const { useEffect } = jest.requireActual('react');
+        focusCallbacks.push(callback);
+        useEffect(() => callback(), [callback]);
+    },
+}));
+
+// Deliberately NOT mocking ../hooks/useStoreReviewPrompt -- that is the code
+// under test.
+jest.mock('expo-store-review', () => ({
+    isAvailableAsync: jest.fn(),
+    requestReview: jest.fn(),
+}));
+
+jest.mock('expo-blur', () => ({
+    BlurView: ({ children, style }: { children: React.ReactNode; style: object }) => {
+        const { View } = jest.requireActual('react-native');
+        return <View style={style} testID="blur-view">{children}</View>;
+    },
+}));
+
+jest.mock('expo-crypto', () => ({
+    randomUUID: jest.fn(() => 'mock-uuid-123'),
+}));
+
+jest.mock('react-native-reanimated', () => {
+    const View = jest.requireActual('react-native').View;
+    const FlatList = jest.requireActual('react-native').FlatList;
+
+    return {
+        __esModule: true,
+        default: { View, FlatList },
+        LinearTransition: { easing: jest.fn(() => ({})) },
+        Easing: { ease: jest.fn() },
+    };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+    SafeAreaView: ({ children, style }: { children: React.ReactNode; style: object }) => {
+        const { View } = jest.requireActual('react-native');
+        return <View style={style} testID="safe-area-view">{children}</View>;
+    },
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../Analytics', () => ({
+    logEvent: jest.fn(),
+}));
+
+jest.mock('../Logger', () => ({
+    __esModule: true,
+    default: { info: jest.fn(), error: jest.fn() },
+    info: jest.fn(),
+    error: jest.fn(),
+}));
+
+jest.mock('../components/GameListItem', () => {
+    return function MockGameListItem({ gameId }: { gameId: string }) {
+        const { View, Text } = jest.requireActual('react-native');
+        return <View testID={`game-list-item-${gameId}`}><Text>{gameId}</Text></View>;
+    };
+});
+
+const mockNavigation = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    reset: jest.fn(),
+    setParams: jest.fn(),
+    setOptions: jest.fn(),
+    addListener: jest.fn(() => jest.fn()),
+    isFocused: jest.fn(() => true),
+} as unknown as NativeStackNavigationProp<ParamListBase, string, undefined>;
+
+const makeGame = (id: string, roundCurrent: number) => ({
+    id,
+    title: `Game ${id}`,
+    dateCreated: 1_700_000_000_000,
+    roundCurrent,
+    roundTotal: roundCurrent + 1,
+    playerIds: [],
+});
+
+/**
+ * A user who has cleared every eligibility gate: three games (the minimum),
+ * a current game they have actually played past the first round, and no prior
+ * prompt on record.
+ */
+const eligibleState = (overrides: { roundCurrent?: number; lastStoreReviewPrompt?: number } = {}) => {
+    const { roundCurrent = 2, lastStoreReviewPrompt = 0 } = overrides;
+    return {
+        settings: {
+            appOpens: 5,
+            devMenuEnabled: false,
+            installId: 'existing-id',
+            rollingGameCounter: 3,
+            currentGameId: 'g1',
+            lastStoreReviewPrompt,
+        },
+        games: {
+            entities: {
+                g1: makeGame('g1', roundCurrent),
+                g2: makeGame('g2', 1),
+                g3: makeGame('g3', 1),
+            },
+            ids: ['g1', 'g2', 'g3'],
+        },
+        players: { entities: {}, ids: [] },
+    };
+};
+
+const renderList = (preloadedState: ReturnType<typeof eligibleState>) => {
+    const store = configureStore({
+        reducer: { settings: settingsReducer, games: gamesReducer, players: playersReducer },
+        preloadedState: preloadedState as Parameters<typeof configureStore>[0]['preloadedState'],
+    });
+    const utils = render(
+        <Provider store={store}>
+            <ListScreen navigation={mockNavigation} />
+        </Provider>
+    );
+    return { store, ...utils };
+};
+
+/** The second focus: the user coming back to the list after a game. */
+const refocus = () => focusCallbacks[focusCallbacks.length - 1]();
+
+describe('ListScreen review prompt (integration)', () => {
+    beforeEach(() => {
+        focusCallbacks.length = 0;
+        jest.clearAllMocks();
+        (StoreReview.isAvailableAsync as jest.Mock).mockResolvedValue(true);
+        (StoreReview.requestReview as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    it('requests a native review and logs review_prompt on return from a game', async () => {
+        renderList(eligibleState());
+
+        refocus();
+
+        await waitFor(() => expect(StoreReview.requestReview).toHaveBeenCalledTimes(1));
+        expect(logEvent).toHaveBeenCalledWith('review_prompt', {
+            game_count: 3,
+            days_since_last: undefined,
+        });
+    });
+
+    it('records the prompt timestamp so the interval starts counting', async () => {
+        const { store } = renderList(eligibleState());
+
+        refocus();
+
+        await waitFor(() => expect(StoreReview.requestReview).toHaveBeenCalled());
+        expect(store.getState().settings.lastStoreReviewPrompt).toBeGreaterThan(0);
+    });
+
+    it('does not prompt on the first focus, when the app is merely opening', async () => {
+        renderList(eligibleState());
+
+        // No refocus() -- only the mount-time focus has happened.
+        await waitFor(() => expect(logEvent).toHaveBeenCalled());
+        expect(StoreReview.requestReview).not.toHaveBeenCalled();
+        expect(logEvent).not.toHaveBeenCalledWith('review_prompt', expect.anything());
+    });
+
+    it('logs review_prompt_skipped when the store front is unavailable', async () => {
+        (StoreReview.isAvailableAsync as jest.Mock).mockResolvedValue(false);
+        renderList(eligibleState());
+
+        refocus();
+
+        await waitFor(() => expect(logEvent).toHaveBeenCalledWith(
+            'review_prompt_skipped',
+            { reason: 'unavailable', game_count: 3 },
+        ));
+        expect(StoreReview.requestReview).not.toHaveBeenCalled();
+    });
+
+    it('stays silent for a user still on the first round of their current game', async () => {
+        // roundCurrent is 0-indexed, so 0 means they have not advanced a round.
+        renderList(eligibleState({ roundCurrent: 0 }));
+
+        refocus();
+
+        await waitFor(() => expect(logEvent).toHaveBeenCalled());
+        expect(StoreReview.requestReview).not.toHaveBeenCalled();
+        expect(logEvent).not.toHaveBeenCalledWith('review_prompt', expect.anything());
+    });
+
+    it('stays silent for a user prompted within the last 90 days', async () => {
+        renderList(eligibleState({ lastStoreReviewPrompt: Date.now() - 10 * 24 * 60 * 60 * 1000 }));
+
+        refocus();
+
+        await waitFor(() => expect(logEvent).toHaveBeenCalled());
+        expect(StoreReview.requestReview).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Verification requested before releasing 3.0.5: that the next version actually prompts for App Store reviews, and that the prompt is logged to Firebase. Both hold on `main` today. This PR adds the test that keeps them holding.

## Answers

**1. Will 3.0.5 prompt?** Yes — and it will be the first 3.x release that does.

`useStoreReviewPrompt` is called from `ListScreen` under `useFocusEffect`, skipping the first focus (app launch) and firing on the return from a game. `currentGameId` survives that navigation — it is only cleared on game deletion — so the eligibility gate can resolve. `expo-store-review` is `~57.0.2`, matching SDK 57. Single call site, so no double-prompt.

**2. Is it logged?** Yes. `review_prompt` with `game_count` and `days_since_last`, plus `review_prompt_skipped` with `reason: 'unavailable' | 'error'`. Both are in the typed catalog in `AnalyticsEvents.ts`, so a wrong name or param is a compile error.

## 3.0.4 never worked

GA4, last 30 days:

| version | users | `review_prompt` | `review_prompt_skipped` | `score_change` |
|---|---|---|---|---|
| **3.0.3** | 469 | **0** | 0 | 179,382 |
| 2.5.9 | 32 | 5 | 0 | 4,340 |
| **3.0.4** | 21 | **0** | **0** | 2,762 |
| 2.5.10 | 11 | 5 | 0 | 2,801 |

Every `review_prompt` in the last 120 days came from 2.5.9 or 2.5.10, where the prompt hung off the pre-v3.0.0 `HomeButton`. No 3.x version has ever logged one, despite carrying an order of magnitude more users.

`review_prompt_skipped` being zero on 3.0.4 is the conclusive part: had the hook run and iOS declined, that event would fire. It does not, because #715's fix (moving the prompt off the unmounted `BackButton`) is not in 3.0.4 — it is unreleased, and ships in 3.0.5.

## Why a test, and why this one

Both historical breakages were wiring, not logic, and both passed CI. The two existing files mock each other's half — `ListScreen.test` mocks the hook, `useStoreReviewPrompt.test` mocks the store and native module — so nothing ever rendered the real screen against the real hook. That seam is exactly where the feature died, twice.

This renders `ListScreen` with real reducers, real selectors and the real hook, stubbing only `expo-store-review` and the analytics transport. Six cases: the prompt fires and logs on return from a game; the timestamp is recorded; nothing fires on first focus; `review_prompt_skipped` on an unavailable store front; silence for a user on round one; silence inside the 90-day interval.

**Mutation-checked** — commenting out `promptForReview()` in `ListScreen` fails three of the six. The old tests still pass under that same change.

## Verification

- `npm test` — 436 passed, 44 suites (was 430/43)
- `npm run lint` — exit 0
- `scripts/release-preflight.sh pr` — all checks pass

## One observation, no change made

`roundCurrent` is 0-indexed, and the gate is `roundCurrent < 1`, so a user must reach round 2 before ever being asked — stricter than the comment's "opened a game but never scored in it". It only delays rather than blocks, since any multi-round game qualifies them, so I left the behaviour alone. Worth a look if single-round games are common for your users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)