### PR TITLE
fix(review-prompt): improve eligibility criteria

### DIFF
--- a/src/AnalyticsEvents.ts
+++ b/src/AnalyticsEvents.ts
@@ -119,13 +119,21 @@ export interface AnalyticsEventParams {
      * the OS, not that the user saw a dialog — iOS silently declines when it has
      * shown too many prompts recently, and never tells us.
      */
-    review_prompt: { game_count: number; days_since_last?: number };
+    review_prompt: {
+        /** High-water game count (rolling_game_counter), not the current list length. */
+        game_count: number;
+        days_since_last?: number;
+    };
     /**
      * We passed our own eligibility gates but no prompt was requested. Only
      * logged for these outcomes — the ordinary "not eligible yet" case is not
      * logged, since it would fire on nearly every navigation home.
      */
-    review_prompt_skipped: { reason: 'unavailable' | 'error'; game_count: number };
+    review_prompt_skipped: {
+        reason: 'unavailable' | 'error';
+        /** High-water game count (rolling_game_counter), not the current list length. */
+        game_count: number;
+    };
 }
 
 export type AnalyticsEventName = keyof AnalyticsEventParams;

--- a/src/hooks/useStoreReviewPrompt.test.tsx
+++ b/src/hooks/useStoreReviewPrompt.test.tsx
@@ -66,6 +66,7 @@ describe('shouldPromptForReview', () => {
 
 interface StoreOpts {
     gameCount?: number;
+    rollingGameCounter?: number;
     hasScored?: boolean;
     lastStoreReviewPrompt?: number;
 }
@@ -86,6 +87,7 @@ const createStore = (opts: StoreOpts = {}) => {
                 lastUsedInteractionType: (opts.hasScored ?? true)
                     ? InteractionType.SwipeVertical
                     : undefined,
+                rollingGameCounter: opts.rollingGameCounter,
             },
             games: { entities, ids },
             players: { entities: { p1: { id: 'p1', playerName: 'P1', scores: [0] } }, ids: ['p1'] },
@@ -131,6 +133,29 @@ describe('useStoreReviewPrompt', () => {
         await result.current();
 
         expect(logEvent).toHaveBeenCalledWith('review_prompt', { game_count: 5, days_since_last: 120 });
+    });
+
+    // 6% of users have played three or more games but keep fewer than three,
+    // because they delete each one as it finishes. Counting the live list
+    // rather than the high-water mark made them permanently unaskable.
+    it('counts games ever played, not games still in the list', async () => {
+        const store = createStore({ gameCount: 1, rollingGameCounter: 8 });
+        const { result } = renderPrompt(store);
+
+        await result.current();
+
+        expect(StoreReview.requestReview).toHaveBeenCalledTimes(1);
+        expect(logEvent).toHaveBeenCalledWith('review_prompt', { game_count: 8, days_since_last: undefined });
+    });
+
+    it('falls back to the live count when the rolling counter is unseeded', async () => {
+        const store = createStore({ gameCount: 5, rollingGameCounter: undefined });
+        const { result } = renderPrompt(store);
+
+        await result.current();
+
+        expect(StoreReview.requestReview).toHaveBeenCalledTimes(1);
+        expect(logEvent).toHaveBeenCalledWith('review_prompt', { game_count: 5, days_since_last: undefined });
     });
 
     it('does nothing when the user is not eligible', async () => {

--- a/src/hooks/useStoreReviewPrompt.test.tsx
+++ b/src/hooks/useStoreReviewPrompt.test.tsx
@@ -9,6 +9,7 @@ import gamesReducer from '../../redux/GamesSlice';
 import playersReducer from '../../redux/PlayersSlice';
 import settingsReducer from '../../redux/SettingsSlice';
 import { logEvent } from '../Analytics';
+import { InteractionType } from '../components/Interactions/InteractionType';
 
 import {
     MIN_GAMES_FOR_REVIEW,
@@ -28,7 +29,7 @@ const NOW = 1_700_000_000_000;
 const daysAgo = (days: number) => NOW - days * MS_PER_DAY;
 
 describe('shouldPromptForReview', () => {
-    const eligible = { gameCount: 5, roundCurrent: 3, lastPrompt: 0, now: NOW };
+    const eligible = { gameCount: 5, hasScored: true, lastPrompt: 0, now: NOW };
 
     it('prompts a user who qualifies and has never been prompted', () => {
         expect(shouldPromptForReview(eligible)).toBe(true);
@@ -42,8 +43,14 @@ describe('shouldPromptForReview', () => {
         expect(shouldPromptForReview({ ...eligible, gameCount: MIN_GAMES_FOR_REVIEW })).toBe(true);
     });
 
-    it('does not prompt a user who has not scored in the current game', () => {
-        expect(shouldPromptForReview({ ...eligible, roundCurrent: 0 })).toBe(false);
+    it('does not prompt a user who has made games but never scored', () => {
+        expect(shouldPromptForReview({ ...eligible, hasScored: false })).toBe(false);
+    });
+
+    // Single-round games are 16% of all scored games. The previous gate keyed
+    // off the current game reaching round 2, so those users were never asked.
+    it('prompts a user whose games never leave the first round', () => {
+        expect(shouldPromptForReview({ ...eligible, hasScored: true })).toBe(true);
     });
 
     it('does not prompt within the interval', () => {
@@ -59,7 +66,7 @@ describe('shouldPromptForReview', () => {
 
 interface StoreOpts {
     gameCount?: number;
-    roundCurrent?: number;
+    hasScored?: boolean;
     lastStoreReviewPrompt?: number;
 }
 
@@ -67,7 +74,7 @@ const createStore = (opts: StoreOpts = {}) => {
     const gameCount = opts.gameCount ?? 5;
     const ids = Array.from({ length: gameCount }, (_, i) => `game-${i}`);
     const entities = Object.fromEntries(ids.map(id => [id, {
-        id, playerIds: ['p1'], dateCreated: 0, roundCurrent: opts.roundCurrent ?? 3, roundTotal: 4, locked: false,
+        id, playerIds: ['p1'], dateCreated: 0, roundCurrent: 0, roundTotal: 1, locked: false,
     }]));
 
     return configureStore({
@@ -76,6 +83,9 @@ const createStore = (opts: StoreOpts = {}) => {
             settings: {
                 currentGameId: ids[0],
                 lastStoreReviewPrompt: opts.lastStoreReviewPrompt ?? 0,
+                lastUsedInteractionType: (opts.hasScored ?? true)
+                    ? InteractionType.SwipeVertical
+                    : undefined,
             },
             games: { entities, ids },
             players: { entities: { p1: { id: 'p1', playerName: 'P1', scores: [0] } }, ids: ['p1'] },

--- a/src/hooks/useStoreReviewPrompt.ts
+++ b/src/hooks/useStoreReviewPrompt.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import * as StoreReview from 'expo-store-review';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { selectCurrentGame, selectLastStoreReviewPrompt } from '../../redux/selectors';
+import { selectLastStoreReviewPrompt } from '../../redux/selectors';
 import { setLastStoreReviewPrompt } from '../../redux/SettingsSlice';
 import { logEvent } from '../Analytics';
 import logger from '../Logger';
@@ -17,8 +17,11 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 export interface ReviewEligibility {
     gameCount: number;
-    /** Current round of the active game; 0 means the user hasn't scored anything yet. */
-    roundCurrent: number;
+    /**
+     * Whether the user has ever committed a score, via any gesture. False for
+     * someone who has created games but never actually played one.
+     */
+    hasScored: boolean;
     /** Epoch ms of the last prompt. 0 = never prompted. */
     lastPrompt: number;
     now: number;
@@ -29,11 +32,15 @@ export interface ReviewEligibility {
  * testable without a store, a renderer, or the native module.
  */
 export const shouldPromptForReview = (
-    { gameCount, roundCurrent, lastPrompt, now }: ReviewEligibility,
+    { gameCount, hasScored, lastPrompt, now }: ReviewEligibility,
 ): boolean => {
     if (gameCount < MIN_GAMES_FOR_REVIEW) return false;
-    // Don't ask someone who opened a game but never scored in it.
-    if (roundCurrent < 1) return false;
+    // Don't ask someone who has made games but never actually played one.
+    //
+    // This used to require the current game to have reached round 2, which was
+    // a poor proxy: single-round games are common (16% of all scored games),
+    // and a user who only ever plays those could never be asked.
+    if (!hasScored) return false;
 
     const daysSinceLastPrompt = (now - lastPrompt) / MS_PER_DAY;
     return daysSinceLastPrompt >= REVIEW_PROMPT_INTERVAL_DAYS;
@@ -55,14 +62,16 @@ export const shouldPromptForReview = (
  */
 export function useStoreReviewPrompt(): () => Promise<void> {
     const gameCount = useAppSelector(state => state.games.ids.length);
-    const roundCurrent = useAppSelector(state => selectCurrentGame(state)?.roundCurrent ?? 0);
+    // Set by every scoring gesture (swipe, half-tap, dial), so it is the
+    // engagement signal the round check was reaching for.
+    const hasScored = useAppSelector(state => state.settings.lastUsedInteractionType !== undefined);
     const lastPrompt = useAppSelector(selectLastStoreReviewPrompt);
     const dispatch = useAppDispatch();
 
     return useCallback(async () => {
         const now = Date.now();
 
-        if (!shouldPromptForReview({ gameCount, roundCurrent, lastPrompt, now })) return;
+        if (!shouldPromptForReview({ gameCount, hasScored, lastPrompt, now })) return;
 
         try {
             // iOS may decline to show anything (its own rate limit); Android
@@ -86,5 +95,5 @@ export function useStoreReviewPrompt(): () => Promise<void> {
             logger.error('STORE_REVIEW_ERROR', error);
             void logEvent('review_prompt_skipped', { reason: 'error', game_count: gameCount });
         }
-    }, [gameCount, roundCurrent, lastPrompt, dispatch]);
+    }, [gameCount, hasScored, lastPrompt, dispatch]);
 }

--- a/src/hooks/useStoreReviewPrompt.ts
+++ b/src/hooks/useStoreReviewPrompt.ts
@@ -16,6 +16,10 @@ export const REVIEW_PROMPT_INTERVAL_DAYS = 90;
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 export interface ReviewEligibility {
+    /**
+     * Games ever accumulated, not games currently in the list. See the hook for
+     * why the distinction matters.
+     */
     gameCount: number;
     /**
      * Whether the user has ever committed a score, via any gesture. False for
@@ -61,7 +65,15 @@ export const shouldPromptForReview = (
  * on a user who was never shown anything.
  */
 export function useStoreReviewPrompt(): () => Promise<void> {
-    const gameCount = useAppSelector(state => state.games.ids.length);
+    // High-water mark rather than the live list length: someone who deletes a
+    // game once it is finished should not be pushed back below the threshold.
+    // 6% of users sit in exactly that position -- three or more games played,
+    // fewer than three kept -- and could never be asked. rollingGameCounter is
+    // maintained by ListScreen; fall back to the live count until it is seeded.
+    const gameCount = useAppSelector(state => Math.max(
+        state.settings.rollingGameCounter ?? 0,
+        state.games.ids.length,
+    ));
     // Set by every scoring gesture (swipe, half-tap, dial), so it is the
     // engagement signal the round check was reaching for.
     const hasScored = useAppSelector(state => state.settings.lastUsedInteractionType !== undefined);

--- a/src/screens/ListScreen.reviewPrompt.test.tsx
+++ b/src/screens/ListScreen.reviewPrompt.test.tsx
@@ -11,6 +11,7 @@ import gamesReducer from '../../redux/GamesSlice';
 import playersReducer from '../../redux/PlayersSlice';
 import settingsReducer from '../../redux/SettingsSlice';
 import { logEvent } from '../Analytics';
+import { InteractionType } from '../components/Interactions/InteractionType';
 
 import ListScreen from './ListScreen';
 
@@ -124,8 +125,8 @@ const makeGame = (id: string, roundCurrent: number) => ({
  * a current game they have actually played past the first round, and no prior
  * prompt on record.
  */
-const eligibleState = (overrides: { roundCurrent?: number; lastStoreReviewPrompt?: number } = {}) => {
-    const { roundCurrent = 2, lastStoreReviewPrompt = 0 } = overrides;
+const eligibleState = (overrides: { hasScored?: boolean; lastStoreReviewPrompt?: number } = {}) => {
+    const { hasScored = true, lastStoreReviewPrompt = 0 } = overrides;
     return {
         settings: {
             appOpens: 5,
@@ -134,12 +135,14 @@ const eligibleState = (overrides: { roundCurrent?: number; lastStoreReviewPrompt
             rollingGameCounter: 3,
             currentGameId: 'g1',
             lastStoreReviewPrompt,
+            lastUsedInteractionType: hasScored ? InteractionType.SwipeVertical : undefined,
         },
         games: {
             entities: {
-                g1: makeGame('g1', roundCurrent),
-                g2: makeGame('g2', 1),
-                g3: makeGame('g3', 1),
+                // All single-round: the previous gate would have blocked these.
+                g1: makeGame('g1', 0),
+                g2: makeGame('g2', 0),
+                g3: makeGame('g3', 0),
             },
             ids: ['g1', 'g2', 'g3'],
         },
@@ -214,9 +217,8 @@ describe('ListScreen review prompt (integration)', () => {
         expect(StoreReview.requestReview).not.toHaveBeenCalled();
     });
 
-    it('stays silent for a user still on the first round of their current game', async () => {
-        // roundCurrent is 0-indexed, so 0 means they have not advanced a round.
-        renderList(eligibleState({ roundCurrent: 0 }));
+    it('stays silent for a user who has made games but never scored', async () => {
+        renderList(eligibleState({ hasScored: false }));
 
         refocus();
 


### PR DESCRIPTION
## Summary
- count games ever played via the rolling game counter instead of only games still in the list
- gate review prompts on whether the user has scored, rather than requiring the current game to pass a round threshold
- add end-to-end ListScreen review prompt coverage through native review and analytics calls

## Validation
- `npm test -- --runTestsByPath src/hooks/useStoreReviewPrompt.test.tsx src/screens/ListScreen.reviewPrompt.test.tsx --coverage=false`