### PR TITLE
ci: auto-submit production builds to both stores

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,10 +1,16 @@
-# Production build for the stores.
+# Production build and store submission.
 #
 # Invoked automatically by release-please.yml once a release is cut, and
 # available on demand via workflow_dispatch for re-runs.
 #
-# This queues the build on EAS and returns; it does NOT submit to App Store
-# Connect or Google Play. Promote the finished binary from the EAS dashboard.
+# This queues the build on EAS and returns. EAS submits the binary once the
+# build finishes: iOS to App Store Connect (awaiting review), Android to the
+# Play internal testing track. Neither reaches users without a human promoting
+# it -- releasing on the App Store, or promoting off the internal track in the
+# Play Console.
+#
+# Submission credentials live on EAS servers, not in GitHub secrets. Set them up
+# once with `eas credentials`; CI authenticates with EXPO_TOKEN alone.
 
 name: Production Build
 
@@ -74,23 +80,39 @@ jobs:
       - name: Release preflight
         run: scripts/release-preflight.sh build "${{ inputs.tag }}"
 
-      - name: Queue production build
+      - name: Queue production build and submission
         run: |
+          # --auto-submit submits when the build completes, on EAS's side, so it
+          # composes with --no-wait: this job queues the work and exits rather
+          # than holding a runner for the length of a native build.
+          #
+          # Neither store release is automatic from here. iOS lands in App Store
+          # Connect awaiting review; Android lands on the internal track (set in
+          # eas.json) and has to be promoted in the Play Console.
           eas build \
             --profile production \
             --platform "${{ inputs.platform }}" \
             --non-interactive \
             --no-wait \
+            --auto-submit \
+            --what-to-test "${{ inputs.tag }}" \
             --message "${{ inputs.tag }} (${{ github.sha }})"
 
       - name: Summary
         run: |
           {
-            echo "### Production build queued"
+            echo "### Production build queued, submission to follow"
             echo
             echo "- Tag: \`${{ inputs.tag }}\`"
             echo "- Platform: \`${{ inputs.platform }}\`"
             echo "- Commit: \`${{ github.sha }}\`"
             echo
-            echo "Track progress and submit to the stores from the [EAS dashboard](https://expo.dev/accounts/wyne/projects/scorepad/builds)."
+            echo "EAS submits automatically once the build finishes."
+            echo
+            echo "| Store | Lands in | Still needs you to |"
+            echo "|-------|----------|--------------------|"
+            echo "| App Store | App Store Connect, awaiting review | Submit for review, then release |"
+            echo "| Play | Internal testing track | Promote to production |"
+            echo
+            echo "Progress: [EAS dashboard](https://expo.dev/accounts/wyne/projects/scorepad/builds)."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,12 @@ Releases are automated with [release-please](https://github.com/googleapis/relea
 1. Every push to `main` updates a standing `chore: release X.Y.Z` pull request. The version and the changelog are derived from conventional-commit titles since the last release.
 2. Merging that PR tags the merge commit `vX.Y.Z` and publishes the GitHub release. Because the tag is created from the same commit that carries the version bump, the file, tag, and release cannot disagree.
 3. The release then queues an EAS production build for both platforms.
-4. **Submission to the App Store / Play Console stays manual** — promote the finished binary from the [EAS dashboard](https://expo.dev/accounts/wyne/projects/scorepad/builds).
+4. EAS submits automatically once each build finishes. **Neither store releases without you**: iOS lands in App Store Connect awaiting review, Android on the Play internal testing track.
+
+| Store | Auto-submitted to | Still needs you to |
+|-------|-------------------|--------------------|
+| App Store | App Store Connect, awaiting review | Submit for review, then release |
+| Google Play | Internal testing track (`track: "internal"` in `eas.json`) | Promote to production |
 
 **Commit titles matter.** The next version is computed from them:
 
@@ -155,8 +160,17 @@ A PR whose title does not parse produces no release at all, so `pr-checks.yml` e
 
 | Secret | Purpose |
 |--------|---------|
-| `EXPO_TOKEN` | EAS authentication for production builds. Already configured. |
+| `EXPO_TOKEN` | EAS authentication for builds *and* submissions. Already configured. |
 | `RELEASE_PLEASE_TOKEN` | Fine-grained PAT scoped to this repo, with **Contents: read and write**, **Pull requests: read and write**, and **Issues: read and write**. Optional but recommended: PRs opened with the default `GITHUB_TOKEN` do not trigger other workflows, so without it the release PR runs no checks until it is merged. Fine-grained PATs expire — when the release PR suddenly stops running checks, this is why. |
+
+**Store credentials are not GitHub secrets.** They live on EAS servers, so CI needs nothing beyond `EXPO_TOKEN`. Set them up once, interactively, from a local checkout:
+
+```bash
+eas credentials --platform ios       # App Store Connect API key
+eas credentials --platform android   # Google Play service account JSON
+```
+
+For iOS choose an App Store Connect API Key rather than an app-specific password: the password route is tied to your Apple ID's 2FA and breaks when it rotates. For Android, create a service account in the Google Play Console (Users and permissions → grant it release permissions) and upload its JSON key to EAS.
 
 **Preflight**, run automatically on the release PR and before every production build, and available locally:
 

--- a/eas.json
+++ b/eas.json
@@ -29,6 +29,7 @@
   "submit": {
     "production": {
       "android": {
+        "track": "internal",
         "changesNotSentForReview": false
       },
       "ios": {


### PR DESCRIPTION
Closes the last manual step in the release chain. The workflow queued a build and stopped; now EAS submits each build as it finishes.

## No new GitHub secrets

Submission credentials live on **EAS servers**, not in repository secrets. CI authenticates with the `EXPO_TOKEN` already configured. Setup is a one-time interactive step from a local checkout:

```bash
eas credentials --platform ios       # App Store Connect API key
eas credentials --platform android   # Google Play service account JSON
```

For iOS, choose an **App Store Connect API Key** over an app-specific password — the password route is tied to your Apple ID's 2FA and breaks silently when it rotates. For Android, create a service account in the Play Console (Users and permissions, granted release permissions) and upload its JSON key to EAS.

`eas credentials` has no `--non-interactive` mode, so I could not verify from here what your project already holds. If iOS submissions were previously done through EAS you may already have a key on file, in which case only Android needs setting up.

## Nothing reaches users automatically

| Store | Auto-submitted to | Still needs you to |
|-------|-------------------|--------------------|
| App Store | App Store Connect, awaiting review | Submit for review, then release |
| Google Play | **Internal testing track** | Promote to production |

Android is pinned to `"track": "internal"` in `eas.json` rather than defaulting implicitly. A bad tag cannot roll out to Play users; the worst case is an unwanted build sitting in internal testing. iOS has no equivalent risk — App Store Connect always requires a human to submit and release.

Say the word if you would rather Android went to the production track as a draft.

## Implementation

`--auto-submit` on the production build. It runs **server-side on build completion**, so it composes with `--no-wait` — the job still queues the work and exits rather than holding a runner for the length of a native build. Verified against `eas build --help`: *"Submit on build complete using the submit profile with the same name as the build profile."*

The tag is passed as `--what-to-test`, so TestFlight builds arrive labelled instead of blank.

The job summary now spells out where each artifact landed and what is left to do.

## Note on eas.json

I first documented the track choice with a comment in `eas.json` — the release preflight caught it immediately, since #724 added a strict-JSON check to that file after the trailing-comma fix. The rationale moved to `AGENTS.md` and the workflow instead. Nice to see the guardrail earn its keep.

## Verification

- `actionlint` — clean
- `scripts/release-preflight.sh pr` — all checks pass, `eas.json` still strict JSON
- `npm run lint` — exit 0
- `npm test` — 439 passed, 44 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)