### PR TITLE
chore: give Android the same run scripts iOS has

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "scripts": {
     "start": "expo start --dev-client",
-    "android": "expo run:android",
+    "android": "npx expo prebuild --clean --platform android && expo run:android --variant release",
+    "android:dev": "APP_VARIANT=development npx expo prebuild --clean --platform android && APP_VARIANT=development expo run:android",
+    "android:preview": "APP_VARIANT=preview npx expo prebuild --clean --platform android && APP_VARIANT=preview expo run:android --variant release",
     "prebuild": "npx expo prebuild",
     "prebuild:clean": "npx expo prebuild --clean",
-    "ios": "npx expo prebuild --clean && expo run:ios --configuration Release",
-    "ios:dev": "APP_VARIANT=development npx expo prebuild --clean && APP_VARIANT=development expo run:ios",
-    "ios:preview": "APP_VARIANT=preview npx expo prebuild --clean && APP_VARIANT=preview expo run:ios --configuration Release",
+    "ios": "npx expo prebuild --clean --platform ios && expo run:ios --configuration Release",
+    "ios:dev": "APP_VARIANT=development npx expo prebuild --clean --platform ios && APP_VARIANT=development expo run:ios",
+    "ios:preview": "APP_VARIANT=preview npx expo prebuild --clean --platform ios && APP_VARIANT=preview expo run:ios --configuration Release",
     "web": "expo start --web",
     "eject": "expo eject",
     "dev": "APP_VARIANT=development expo start",


### PR DESCRIPTION
## What

Adds `android:dev` and `android:preview`, makes `android` prebuild like its iOS counterpart, and scopes every prebuild to a single platform.

| | production | development | preview |
|---|---|---|---|
| **iOS** | `ios` (Release) | `ios:dev` (Debug) | `ios:preview` (Release) |
| **Android** | `android` (release) | `android:dev` (debug) | `android:preview` (release) |

## Why

`android` was a bare `expo run:android` while iOS had three variants that each prebuild first. Two consequences:

- **No way to launch the dev or preview app on Android.** `APP_VARIANT` was never set, so `expo run:android` only ever built `com.wyne.scorepad`.
- **Android silently missed newly added native modules.** Without a prebuild step, `android/` was never regenerated — which is exactly how it missed `expo-glass-effect` and `@expo/ui` from #738.

`--variant release` is Android's equivalent of `--configuration Release`. Release signs with the debug keystore (`android/app/build.gradle`), so it installs on an emulator with no signing setup.

## The one change beyond symmetry

Every prebuild is now scoped with `--platform`, **including the three iOS scripts**.

A bare `prebuild --clean` regenerates *both* native directories, so building for one platform threw away the other's. Switching between them meant a full round trip each time — and on this project an iOS prebuild is a complete Pod install with static frameworks and Firebase. Scoping each script to its own platform stops that.

`prebuild` and `prebuild:clean` are left platform-agnostic, since covering both is the point of having them.

## Testing

Scripts only, no source changes. `npm test` passes (444 tests, 45 suites). The script bodies are verified by inspection — `npm run` lists them as intended, and the release signing config was checked against `android/app/build.gradle` before choosing `--variant release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)