### PR TITLE
ci: bump release-please-action to v5 for the Node 24 runtime

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## What

`googleapis/release-please-action@v4` → `@v5`.

## Why

The [latest release run](https://github.com/wyne/scorepad-react-native/actions/runs/34177248948) warns:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `googleapis/release-please-action@v4`

v4's `action.yml` declares `using: 'node20'`. v5 declares `using: 'node24'`.

## Why the bump is safe

[v5.0.0](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0)'s only breaking change is the Node 24 upgrade itself. Checked against what this workflow actually uses:

- **Inputs** — `token`, `config-file`, `manifest-file` all still declared in v5's `action.yml`.
- **Outputs** — `release_created`, `tag_name` and `version` are still emitted (`src/index.ts`, unchanged output plumbing). `release-build.yml` is triggered off `release_created` and `tag_name`, so those mattering was worth confirming.

v5 also carries release-please core `17.3.0` → `17.6.0`.

## Two related findings, not fixed here

Same deprecation, different workflows — out of scope for this PR, happy to do either:

- **`amannn/action-semantic-pull-request@v5`** in `pr-checks.yml` is also `node20`. [v6.1.1](https://github.com/amannn/action-semantic-pull-request/releases/tag/v6.0.0) is `node24`, and its only breaking change is likewise the Node upgrade — an equally clean bump.
- **`romeovs/lcov-reporter-action@v0.4.0`** in `node.yml` is `node20` with **no newer release** (v0.4.0 is from May 2024). Nothing to bump to; it will keep warning until upstream moves or it gets replaced.

Everything else is already on a current runtime: `actions/*@v7`, `github/codeql-action@v4`, `expo/expo-github-action@v9` (node24), `anthropics/claude-code-action@v1` (composite).

## Testing

Workflow-only change; it can't be verified before merge, since release-please runs on push to `main`. The next run after merge should drop the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)