### PR TITLE
ci: run the EAS workflows on Node 22

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: 'npm'
       - uses: expo/expo-github-action@v9
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -62,10 +62,10 @@ jobs:
           ref: ${{ inputs.ref || inputs.tag }}
           fetch-depth: 0
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Set up EAS


### PR DESCRIPTION
## What

`release-build.yml` and `beta.yml` move from Node 20.x to 22.x.

## Why

The [production build](https://github.com/wyne/scorepad-react-native/actions/runs/34177248948/job/101909042003) failed at **Set up EAS**, 19 seconds in, before anything was queued:

```
error @oclif/plugin-autocomplete@3.3.0: The engine "node" is incompatible
with this module. Expected version ">=22.0.0". Got "20.20.2"
error Found incompatible module.
##[error]The process '/usr/local/bin/yarn' failed with exit code 1
```

Both workflows pin `eas-version: latest`, so this arrived on its own — a current `eas-cli` pulls oclif dependencies that require Node ≥ 22, and installing it on Node 20 now fails outright.

## Both, not just the one that failed

`beta.yml` sets up EAS identically on the same Node version, so it is already broken — just latently, until the next push to `beta`. Fixing only the workflow that happened to run would leave that one to fail the same way later.

## Deliberately left alone

- **`node.yml` (20.x), `release-preflight.yml` (20.x), `pr-checks.yml` (18.x)** — none install `eas-cli`, so none hit this. Worth noting `pr-checks.yml` on 18.x is well past EOL, but that's a separate change with its own risk.
- **`.nvmrc` (20.19.4)** — local dev, not CI. If you run `eas` locally it will hit the same engine error, so that's worth bumping too, but it changes your local toolchain and shouldn't ride along in a CI fix.

## Why 22 and not 24

22.x is the smallest bump that satisfies the `>=22.0.0` constraint, and it's an active LTS. 24 would work too and is also LTS; I stayed one major back to keep the change minimal, since the actual native builds run on EAS's infrastructure rather than this runner. Easy to move up later if you'd rather be on 24.

Note this is unrelated to the Node 20 *action runtime* deprecation warning in the same run — that one is `release-please-action`, fixed separately in #740.

## Testing

Workflow-only change, and neither path can be exercised before merge: `release-build.yml` is triggered by release-please cutting a release, and `beta.yml` by a push to `beta`. The failure is unambiguous in the log, though — a version constraint, not a flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)