### PR TITLE
ci: drop --what-to-test so the iOS submission can be scheduled

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -89,13 +89,17 @@ jobs:
           # Neither store release is automatic from here. iOS lands in App Store
           # Connect awaiting review; Android lands on the internal track (set in
           # eas.json) and has to be promoted in the Play Console.
+          #
+          # No --what-to-test: eas-cli sends it as the iOS submission's
+          # `changelog`, which EAS gates to Enterprise plans, and the whole
+          # submission is rejected rather than the field being dropped. Set
+          # TestFlight's "What to Test" in App Store Connect instead.
           eas build \
             --profile production \
             --platform "${{ inputs.platform }}" \
             --non-interactive \
             --no-wait \
             --auto-submit \
-            --what-to-test "${{ inputs.tag }}" \
             --message "${{ inputs.tag }} (${{ github.sha }})"
 
       - name: Summary


### PR DESCRIPTION
## What

Removes `--what-to-test` from the `eas build` call in `release-build.yml`.

## Why

The [3.1.1 release run](https://github.com/wyne/scorepad-react-native/actions/runs/34177759006/job/101910511392) got further than the last one — Set up EAS passed on Node 22, dependencies installed, preflight passed, both builds were created and the **Android submission was scheduled** — then:

```
🍏 iOS submission
✔ App Store Connect API Key already set up.
- Scheduling iOS submission
✖ Failed to schedule iOS submission
This submission specified the `changelog` parameter.
Changelog submission is currently available for Enterprise plan only.
    Error: GraphQL request failed.
```

`eas.json` never mentions `changelog`. It comes from the CLI flag: eas-cli maps `--what-to-test` straight onto the iOS submission's `changelog` field —

```js
// eas-cli/build/submit/ios/IosSubmitter.js:71
changelog: whatToTest,
```

— and EAS gates that field to Enterprise plans. Critically it **rejects the entire submission** rather than ignoring the unsupported field, so a flag whose only job was annotating the TestFlight build took the release step down with it.

That also explains the asymmetry in the log: `--what-to-test` is iOS-only, which is why Android scheduled fine and only iOS failed.

## Nothing replaces it

The restriction is the plan, not the syntax, so there's no CI-side equivalent. "What to Test" gets set in App Store Connect. A comment in the workflow records why the flag is absent, so it doesn't get helpfully re-added later.

## State left behind by the failed run

Worth knowing before merging — that run was **partially successful**, and merging this won't retroactively fix it:

| | Build | Submission |
|---|---|---|
| Android | `09ec08a7` queued, v3.1.1 (96) | ✅ scheduled |
| iOS | `090b9fdf` queued, v3.1.1 (60) | ❌ not scheduled |

The iOS build itself is fine and will finish on EAS. It just won't auto-submit, so 3.1.1 needs a manual `eas submit -p ios` (or a submit from the EAS dashboard) against build `090b9fdf`. This fix applies from the next release onward.

## Testing

Workflow-only, and unverifiable before merge — `release-build.yml` only runs when release-please cuts a release. The failure is a plan-level API rejection rather than a flake, and the flag-to-field mapping was confirmed in the installed eas-cli source rather than inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)