### PR TITLE
fix(settings): label the analytics state in the version alert

### DIFF
--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -147,10 +147,16 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     };
 
     const alertWithVersion = () => {
+        // Same predicate App.tsx uses to call setAnalyticsCollectionEnabled(false),
+        // so this line cannot disagree with what the app is actually doing. Unset
+        // means enabled, which is the production case — reading the raw variable
+        // is what printed "undefined" in store builds.
+        const analyticsEnabled = process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS !== 'false';
+
         Alert.alert('ScorePad with Rounds\n' +
             `v${appVersion} (${buildNumber})\n` +
             `${Platform.OS} ${Platform.Version}\n` +
-            (process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS)
+            `Analytics: ${analyticsEnabled ? 'on' : 'off'}`
         );
         void logEvent('view_version');
     };


### PR DESCRIPTION
## What

Tapping the version number in Settings showed a bare fourth line reading `undefined`:

```
ScorePad with Rounds
v3.1.1 (60)
ios 27.0
undefined          ← was meant to be the analytics state
```

Now:

```
ScorePad with Rounds
v3.1.1 (60)
ios 27.0
Analytics: on
```

## Why it happened

The alert concatenated `process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS` directly into the string. `eas.json` sets that variable for the `development` and `preview` build profiles only — `production` has no `env` block at all, so in a store build it is unset and JS stringifies it as `"undefined"`.

Two things follow from that, and only the first is a bug:

- **Unset was never handled.** Unset is the normal production state and means *enabled*, but the raw value was printed rather than interpreted.
- **The line had no label**, so even on a dev build it rendered a bare `false` with nothing saying what it referred to.

## The flag itself is fine

`App.tsx` disables collection when the variable is exactly `'false'`:

```js
if (process.env.EXPO_PUBLIC_FIREBASE_ANALYTICS == 'false') {
    analytics().setAnalyticsCollectionEnabled(false);
}
```

This reuses that same predicate (`!== 'false'`) rather than printing the raw value, so the line cannot drift out of agreement with what the app actually does. Behavior is unchanged — display only.

## Testing

`npm run lint` clean, 444 tests pass. No test covers `AppSettingsScreen` (there is no test file for it), so this is verified by reading against `App.tsx`'s predicate rather than by a new assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)