### PR TITLE
fix(fab): stop an outside tap on the open menu reaching the list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.22.5",
-        "@expo/ui": "~57.0.16",
         "@expo/vector-icons": "^15.1.1",
         "@gorhom/bottom-sheet": "^5.2.14",
         "@quidone/react-native-wheel-picker": "^1.7.0",
@@ -3516,35 +3515,6 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
     },
-    "node_modules/@expo/ui": {
-      "version": "57.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-57.0.16.tgz",
-      "integrity": "sha512-3MK74dEPE4mwlv0VbyQKepmHigOs2bcOvay2SFqc1/QSywVTOjbkNPYUbq2H+LyOLP2sHMazrPBwfXGiYn3q7A==",
-      "license": "MIT",
-      "dependencies": {
-        "sf-symbols-typescript": "^2.1.0",
-        "vaul": "^1.1.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "*",
-        "expo": "*",
-        "react": "*",
-        "react-dom": "*",
-        "react-native": "*",
-        "react-native-worklets": "*"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native-worklets": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@expo/vector-icons": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
@@ -5558,320 +5528,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
-      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
-      "license": "MIT"
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
-      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
-      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
-      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-dismissable-layer": "1.1.19",
-        "@radix-ui/react-focus-guards": "1.1.6",
-        "@radix-ui/react-focus-scope": "1.1.16",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-portal": "1.1.17",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.7.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
-      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-effect-event": "0.0.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
-      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
-      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-id": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
-      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
-      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
-      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
-      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
-      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
-      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
-      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-use-effect-event": "0.0.5",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
-      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
-      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
@@ -7914,18 +7570,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/aria-hidden": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -9905,12 +9549,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "8.0.4",
@@ -12953,15 +12591,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/get-package-type": {
@@ -19199,75 +18828,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.3",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-style-singleton": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-test-renderer": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
@@ -21987,27 +21547,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/use-latest-callback": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
@@ -22015,28 +21554,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8"
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -22142,19 +21659,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vaul": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
-      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-dialog": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/vlq": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.22.5",
-    "@expo/ui": "~57.0.16",
     "@expo/vector-icons": "^15.1.1",
     "@gorhom/bottom-sheet": "^5.2.14",
     "@quidone/react-native-wheel-picker": "^1.7.0",

--- a/src/components/FloatingActionButton.test.tsx
+++ b/src/components/FloatingActionButton.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { ParamListBase } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { configureStore } from '@reduxjs/toolkit';
-import { act, fireEvent, render } from '@testing-library/react-native';
+import { act, render } from '@testing-library/react-native';
 import { Keyboard } from 'react-native';
 import { Provider } from 'react-redux';
 
@@ -27,31 +27,6 @@ jest.mock('../ColorPalette', () => ({
 
 jest.mock('react-native-elements', () => ({
     Icon: () => null,
-}));
-
-jest.mock('@expo/ui/swift-ui', () => {
-    const { Pressable, Text, View } = jest.requireActual('react-native');
-
-    return {
-        Host: ({ children, testID }: { children: React.ReactNode; testID?: string }) => (
-            <View testID={testID}>{children}</View>
-        ),
-        Menu: ({ children }: { children: React.ReactNode }) => (
-            <View testID="player-count-menu">{children}</View>
-        ),
-        Button: ({ label, onPress }: { label: string; onPress: () => void }) => (
-            <Pressable accessibilityLabel={label} onPress={onPress}><Text>{label}</Text></Pressable>
-        ),
-        Image: () => null,
-    };
-});
-
-jest.mock('@expo/ui/swift-ui/modifiers', () => ({
-    buttonStyle: jest.fn(),
-    contentShape: jest.fn(),
-    frame: jest.fn(),
-    glassEffect: jest.fn(),
-    shapes: { circle: jest.fn() },
 }));
 
 // Read through a getter: the component reads LIQUID_GLASS at render time, so
@@ -161,19 +136,5 @@ describe('FloatingActionButton', () => {
         );
 
         expect(getByTestId('add-game-button')).toBeTruthy();
-    });
-
-    it('dismisses the keyboard when a player count is picked on liquid glass', () => {
-        mockLiquidGlass = true;
-
-        const { getByLabelText } = render(
-            <Provider store={createMockStore()}>
-                <FloatingActionButton navigation={mockNavigation} />
-            </Provider>
-        );
-
-        fireEvent.press(getByLabelText('2 Players'));
-
-        expect(Keyboard.dismiss).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Button, Host, Image, Menu } from '@expo/ui/swift-ui';
-import { buttonStyle, contentShape, frame, glassEffect, shapes } from '@expo/ui/swift-ui/modifiers';
 import { MenuAction, MenuView } from '@react-native-menu/menu';
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { GlassView } from 'expo-glass-effect';
 import { Keyboard, StyleSheet, View } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -24,19 +23,18 @@ interface Props {
     navigation: NativeStackNavigationProp<ParamListBase, string, undefined>;
 }
 
-const playerCountLabel = (count: number) => `${count}${count == 1 ? ' Player' : ' Players'}`;
-
 const FloatingActionButton: React.FunctionComponent<Props> = ({ navigation }) => {
     const theme = useTheme();
     const dispatch = useAppDispatch();
     const gameCount = useAppSelector(state => selectGameIds(state).length);
     const insets = useSafeAreaInsets();
+    const [menuOpen, setMenuOpen] = useState(false);
 
     const playerNumberOptions = [...Array.from(Array(MAX_PLAYERS).keys(), n => n + 1)];
 
     const menuActions: MenuAction[] = playerNumberOptions.map((number) => ({
         id: number.toString(),
-        title: playerCountLabel(number),
+        title: number.toString() + (number == 1 ? ' Player' : ' Players'),
     }));
 
     const addGameHandler = async (playerCount: number) => {
@@ -49,101 +47,102 @@ const FloatingActionButton: React.FunctionComponent<Props> = ({ navigation }) =>
         });
     };
 
-    const selectPlayerCount = (playerCount: number) => {
-        Keyboard.dismiss();
-        addGameHandler(playerCount);
-    };
+    const icon = <Icon name="plus" type="font-awesome-5" size={24} color="#FFFFFF" />;
 
     return (
-        <View testID="add-game-button-container" style={[styles.container, {
-            bottom: insets.bottom + FAB_BOTTOM_MARGIN,
-            right: insets.right + FAB_EDGE_MARGIN,
-        }]}>
-            {LIQUID_GLASS ? (
-                // SwiftUI owns the whole control here, which is the point.
-                // MenuView's anchor is a UIButton, and a UIControl consumes the
-                // touch rather than passing it to subviews — so a GlassView
-                // nested inside one never sees the touch-down that drives the
-                // interactive glass. Inside SwiftUI the touch reaches the
-                // label, so an interactive glass effect there responds.
-                <Host style={StyleSheet.absoluteFill} testID="add-game-button">
-                    <Menu
-                        label={
-                            // The glass goes on the label, sized by the frame
-                            // ahead of it, so the circle is exactly FAB_SIZE.
-                            // `.glassProminent` as a button style would instead
-                            // wrap the glyph in the style's own padding and size
-                            // itself, which is how this ended up much smaller
-                            // than the disc it replaced.
-                            <Image
-                                systemName="plus"
-                                size={24}
-                                color="#FFFFFF"
-                                modifiers={[
-                                    frame({ width: FAB_SIZE, height: FAB_SIZE }),
-                                    glassEffect({
-                                        glass: { variant: 'regular', interactive: true, tint: theme.tint },
-                                        shape: 'circle',
-                                    }),
-                                    // Without this the menu's dismissal morphs
-                                    // back into the glyph's own bounds — a small
-                                    // square — rather than the button. The
-                                    // preview shape has to be stated separately
-                                    // from the glass shape.
-                                    contentShape(shapes.circle(), ['interaction', 'contextMenuPreview']),
-                                ]}
-                            />
-                        }
-                        modifiers={[buttonStyle('plain')]}
-                    >
-                        {playerNumberOptions.map((number) => (
-                            <Button
-                                key={number}
-                                label={playerCountLabel(number)}
-                                onPress={() => selectPlayerCount(number)}
-                            />
-                        ))}
-                    </Menu>
-                </Host>
-            ) : (
+        <>
+            {/*
+              * The UIKit menu's dismissal tap is not being absorbed before React
+              * Native sees it, so tapping outside an open menu also lands on
+              * whatever sits underneath — usually a game row. This swallows that
+              * touch for as long as the menu is up. The menu still dismisses
+              * itself; this only stops the tap continuing into the list.
+              */}
+            {menuOpen && (
+                <View style={styles.dismissShield} testID="menu-dismiss-shield" />
+            )}
+            <View testID="add-game-button-container" style={[styles.container, {
+                bottom: insets.bottom + FAB_BOTTOM_MARGIN,
+                right: insets.right + FAB_EDGE_MARGIN,
+            }]}>
                 <MenuView
                     style={StyleSheet.absoluteFill}
                     onOpenMenu={() => {
                         Keyboard.dismiss();
+                        setMenuOpen(true);
                     }}
-                    onPressAction={({ nativeEvent }) => {
-                        selectPlayerCount(parseInt(nativeEvent.event));
+                    onCloseMenu={() => {
+                        setMenuOpen(false);
+                    }}
+                    onPressAction={async ({ nativeEvent }) => {
+                        Keyboard.dismiss();
+                        const playerNumber = parseInt(nativeEvent.event);
+                        addGameHandler(playerNumber);
                     }}
                     actions={menuActions}
                 >
-                    <View
-                        accessibilityLabel="Add game"
-                        accessibilityRole="button"
-                        style={[styles.fab, { backgroundColor: theme.tint }]}
-                        testID="add-game-button"
-                    >
-                        <Icon name="plus" type="font-awesome-5" size={24} color="#FFFFFF" />
-                    </View>
-                </MenuView>
-            )}
-        </View>
+                    {LIQUID_GLASS ? (
+                        // Tinted rather than clear: the button has to stay findable
+                        // while the games list scrolls under it, and the accent is
+                        // what makes it findable.
+                        //
+                        // No `isInteractive`: MenuView's anchor is a UIButton, and
+                        // a UIControl consumes the touch itself rather than passing
+                        // it to subviews, so the glass never sees the touch-down
+                        // that drives the effect.
+                        <GlassView
+                            accessibilityLabel="Add game"
+                            accessibilityRole="button"
+                            style={styles.fab}
+                            testID="add-game-button"
+                            tintColor={theme.tint}
+                        >
+                            {icon}
+                        </GlassView>
+                    ) : (
+                        <View
+                            accessibilityLabel="Add game"
+                            accessibilityRole="button"
+                            style={[styles.fab, styles.fabFlat, { backgroundColor: theme.tint }]}
+                            testID="add-game-button"
+                        >
+                            {icon}
+                        </View>
+                    )}
+                    </MenuView>
+            </View>
+        </>
     );
 };
 
 const styles = StyleSheet.create({
+    dismissShield: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 99,
+    },
     container: {
         position: 'absolute',
         width: FAB_SIZE,
         height: FAB_SIZE,
         zIndex: 100,
     },
-    /** Glass lifts itself off the background; a flat disc needs the shadow to. */
+    /**
+     * The glass is the shape, so the circle lives on the element that draws the
+     * effect — a `borderRadius` set on an ancestor would leave the glass square.
+     */
     fab: {
         width: FAB_SIZE,
         height: FAB_SIZE,
         borderRadius: FAB_SIZE / 2,
         justifyContent: 'center',
         alignItems: 'center',
+    },
+    /** Glass lifts itself off the background; a flat disc needs the shadow to. */
+    fabFlat: {
         shadowColor: '#000',
         shadowOpacity: 0.3,
         shadowOffset: { width: 0, height: 4 },


### PR DESCRIPTION
## The bug

Tapping outside the open player-count menu dismissed it *and* passed the touch through to whatever was underneath — usually selecting a game from the list.

`MenuView` exposes `onOpenMenu` / `onCloseMenu` (the FAB already used the first for `Keyboard.dismiss`), so this tracks the open state and renders a full-screen touch-swallowing view while the menu is up. That works without needing to know *why* UIKit isn't absorbing the tap.

## Also reverts the SwiftUI FAB

The button goes back to `MenuView` + `expo-glass-effect`'s `GlassView`, and `@expo/ui` is removed — the FAB was its only consumer.

The SwiftUI `Menu` was only ever adopted to get interactive glass, which a `UIButton` anchor can't provide (a `UIControl` consumes the touch rather than passing it to subviews, so `isInteractive` is inert there). It isn't needed for the material itself. The cost of keeping it is the press physics on the FAB; the sheet buttons keep theirs, since `Pressable` doesn't intercept the same way.

> [!WARNING]
> **Neither half of this is verified on device.** The tap-through was originally diagnosed as a consequence of the SwiftUI Menu — that turned out to be wrong: it reproduces on a build with no glass modules at all, on code equivalent to the pre-liquid-glass FAB. So the revert is not what fixes it, and the shield is the actual fix.
>
> Two things to check before merging:
> - **Does the shield work?** If `onCloseMenu` fires before the tap is delivered to RN, the shield is already gone and the tap still lands. The fix there is holding it a beat longer after close, not abandoning the approach.
> - **Do you still want the revert?** It was justified by the wrong diagnosis. If you preferred the SwiftUI FAB's press physics, the two halves can be separated — though the shield depends on `onOpenMenu`/`onCloseMenu`, which `@expo/ui`'s `Menu` does not provide.

## Testing

`npm run lint` clean, 443 tests pass. Requires a native rebuild, since removing `@expo/ui` changes the native module set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)