### PR TITLE
fix(edit-player): give the screen a top margin and a full-height scroll area

### DIFF
--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -167,7 +167,11 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     };
 
     return (
-        <ScrollView style={{ flex: 1 }} keyboardShouldPersistTaps="handled">
+        <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+        >
 
             <View style={{ position: 'relative', zIndex: 1 }}>
                 <Input
@@ -227,6 +231,14 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
 export default EditPlayerScreen;
 
 const styles = StyleSheet.create({
+    scrollContent: {
+        // Grow to fill the screen even when the palette is shorter than it, so
+        // the empty space below stays part of the scroll view and can be
+        // dragged. Without this the content container ends at the palette and
+        // only touches landing on the content scroll.
+        flexGrow: 1,
+        paddingTop: 16,
+    },
     input: {
     },
     suggestionsContainer: {


### PR DESCRIPTION
## Two problems, one fix

**No top margin.** The `ScrollView` had no `contentContainerStyle`, so the player name input sat flush against the navigation header.

**The scroll area stopped at the content.** The content container ended at the bottom of the colour palette, so the empty space below it belonged to nothing — you couldn't grab and drag the view from there, which feels broken on a screen that is mostly empty space.

## The fix

```js
scrollContent: {
    flexGrow: 1,
    paddingTop: 16,
}
```

`flexGrow: 1` makes the container fill the viewport regardless of how short the palette is, so the empty area below stays part of the scroll view. `ListScreen.tsx` already uses the same `flexGrow` on its list for the same reason.

## Testing

`npm run lint` clean, 444 tests pass (`EditPlayerScreen`'s own 34 included). JS-only — no rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)