### PR TITLE
fix(ui): one section label style across the app

### DIFF
--- a/src/components/ColorPalettes/ColorSelector.test.tsx
+++ b/src/components/ColorPalettes/ColorSelector.test.tsx
@@ -116,7 +116,7 @@ describe('ColorSelector', () => {
             </Provider>
         );
 
-        expect(getByText('Current Pallete')).toBeTruthy();
+        expect(getByText('Current palette')).toBeTruthy();
     });
 
     it('should render other palettes section', () => {
@@ -128,7 +128,7 @@ describe('ColorSelector', () => {
             </Provider>
         );
 
-        expect(getByText('Other Palletes')).toBeTruthy();
+        expect(getByText('Other palettes')).toBeTruthy();
     });
 
     it('should render colors from current palette', () => {
@@ -287,8 +287,8 @@ describe('ColorSelector', () => {
         );
 
         // Should still render the sections
-        expect(getByText('Current Pallete')).toBeTruthy();
-        expect(getByText('Other Palletes')).toBeTruthy();
+        expect(getByText('Current palette')).toBeTruthy();
+        expect(getByText('Other palettes')).toBeTruthy();
     });
 
     it('should handle different player colors correctly', () => {
@@ -345,8 +345,8 @@ describe('ColorSelector', () => {
         );
 
         // Should still render section titles
-        expect(getByText('Current Pallete')).toBeTruthy();
-        expect(getByText('Other Palletes')).toBeTruthy();
+        expect(getByText('Current palette')).toBeTruthy();
+        expect(getByText('Other palettes')).toBeTruthy();
     });
 
     it('should handle multiple rapid color selections', () => {

--- a/src/components/ColorPalettes/ColorSelector.tsx
+++ b/src/components/ColorPalettes/ColorSelector.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { updatePlayer } from '../../../redux/PlayersSlice';
 import { selectCurrentGame } from '../../../redux/selectors';
 import { logEvent } from '../../Analytics';
 import { getPalette, getPalettes } from '../../ColorPalette';
-import { useTheme } from '../../theme';
+import SectionLabel from '../SectionLabel';
 
 interface ColorSelectorProps {
     playerId: string;
@@ -27,7 +27,6 @@ const ColorButton: React.FC<{ color: string, playerColor: string | undefined; }>
 };
 
 const ColorSelector: React.FC<ColorSelectorProps> = ({ playerId }) => {
-    const theme = useTheme();
     const colorPalettes = getPalettes();
     const currentGameId = useAppSelector(state => selectCurrentGame(state)?.id);
     const currentGame = useAppSelector(state => selectCurrentGame(state));
@@ -54,12 +53,10 @@ const ColorSelector: React.FC<ColorSelectorProps> = ({ playerId }) => {
         <View style={{ flexDirection: 'column' }}>
 
 
-            <View style={[styles.titleContainer]}>
-                <Text style={[styles.title, { color: theme.text }]}>Current Pallete</Text>
-            </View>
+            <SectionLabel>Current palette</SectionLabel>
 
             {currentPalette &&
-                <View style={{ flexDirection: 'row', marginVertical: 5 }}>
+                <View style={styles.paletteRow}>
                     {
                         getPalette(currentPalette).map((color, i) => (
                             <TouchableOpacity
@@ -74,13 +71,11 @@ const ColorSelector: React.FC<ColorSelectorProps> = ({ playerId }) => {
             }
 
 
-            <View style={[styles.titleContainer]}>
-                <Text style={[styles.title, { color: theme.text }]}>Other Palletes</Text>
-            </View>
+            <SectionLabel>Other palettes</SectionLabel>
 
             {colorPalettes.map((palette, palette_index) => (
                 currentPalette !== palette && (
-                    <View style={{ flexDirection: 'row', marginVertical: 5 }} key={'v' + palette_index}>
+                    <View style={styles.paletteRow} key={'v' + palette_index}>
                         {
                             getPalette(palette).map((color, i) => (
                                 <TouchableOpacity
@@ -101,6 +96,14 @@ const ColorSelector: React.FC<ColorSelectorProps> = ({ playerId }) => {
 export default ColorSelector;
 
 const styles = StyleSheet.create({
+    paletteRow: {
+        flexDirection: 'row',
+        marginVertical: 5,
+        // Each badge carries its own 5pt side margin, so the row is pulled in
+        // by that much to land the first swatch on the same 20pt gutter as the
+        // labels and the name field above.
+        marginHorizontal: 15,
+    },
     colorBadge: {
         borderColor: '#999',
         borderWidth: 1,
@@ -111,11 +114,4 @@ const styles = StyleSheet.create({
         padding: 5,
         width: 25,
     },
-    title: {
-    },
-    titleContainer: {
-        flexDirection: 'column',
-        justifyContent: 'space-between',
-        marginVertical: 10,
-    }
 });

--- a/src/components/SectionLabel.tsx
+++ b/src/components/SectionLabel.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { StyleProp, StyleSheet, Text, TextStyle } from 'react-native';
+
+import { useTheme } from '../theme';
+
+interface Props {
+    children: React.ReactNode;
+    /**
+     * Horizontal inset, matched to the content the label sits above so the two
+     * line up. Relative to the label's own parent, not the screen — inside a
+     * container that already insets its children, pass only the remainder.
+     *
+     * Defaults to the app's 20pt gutter.
+     */
+    inset?: number;
+    style?: StyleProp<TextStyle>;
+}
+
+/**
+ * The single section and field label used across the app.
+ *
+ * Sentence case rather than the uppercase some screens used before: SwiftUI's
+ * own list headers dropped uppercase, and it reads badly on field labels
+ * ("PLAYER ONE NAME"). Secondary colour keeps the label below the content it
+ * introduces in the hierarchy — one screen had these in the primary colour,
+ * which made the header louder than the thing it labelled.
+ */
+const SectionLabel: React.FunctionComponent<Props> = ({ children, inset = 20, style }) => {
+    const theme = useTheme();
+
+    return (
+        <Text
+            accessibilityRole="header"
+            style={[styles.label, { color: theme.textSecondary, marginHorizontal: inset }, style]}
+        >
+            {children}
+        </Text>
+    );
+};
+
+const styles = StyleSheet.create({
+    label: {
+        fontSize: 13,
+        fontWeight: '600',
+        marginTop: 20,
+        marginBottom: 6,
+    },
+});
+
+export default SectionLabel;

--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -12,6 +12,7 @@ import { logEvent } from '../Analytics';
 import RotatingIcon from '../components/AppInfo/RotatingIcon';
 import { loadSeedData } from '../components/AppInfo/SeedData';
 import HeaderButton from '../components/Buttons/HeaderButton';
+import SectionLabel from '../components/SectionLabel';
 import { FEATURE_KEEP_SCREEN_AWAKE } from '../constants';
 import { useTheme } from '../theme';
 
@@ -34,7 +35,7 @@ const AppSettingsScreen: React.FunctionComponent<Props> = ({ navigation }) => {
     }, [navigation, theme.tint]);
     const Section = ({ children, title }: { children: React.ReactNode, title: string; }) => (
         <>
-            <Text style={[styles.sectionHeader, { color: theme.textTertiary }]}>{title}</Text>
+            <SectionLabel inset={40}>{title}</SectionLabel>
             <View style={[styles.section, { backgroundColor: theme.backgroundSecondary }]}>
                 {children}
             </View>
@@ -286,13 +287,6 @@ const styles = StyleSheet.create({
         margin: 10,
         alignContent: 'center',
         justifyContent: 'center',
-    },
-    sectionHeader: {
-        fontSize: 12,
-        marginTop: 20,
-        padding: 5,
-        paddingHorizontal: 40,
-        textTransform: 'uppercase',
     },
     section: {
         paddingHorizontal: 20,

--- a/src/screens/EditGameScreen.test.tsx
+++ b/src/screens/EditGameScreen.test.tsx
@@ -258,7 +258,7 @@ describe('EditGameScreen', () => {
             </Provider>
         );
 
-        expect(getByText('Game Title')).toBeTruthy();
+        expect(getByText('Game title')).toBeTruthy();
         expect(getByText('Players')).toBeTruthy();
         expect(getByTestId('edit-game')).toBeTruthy();
         expect(getByTestId('draggable-flatlist')).toBeTruthy();

--- a/src/screens/EditGameScreen.tsx
+++ b/src/screens/EditGameScreen.tsx
@@ -13,6 +13,7 @@ import { logEvent } from '../Analytics';
 import HeaderButton from '../components/Buttons/HeaderButton';
 import EditGame from '../components/EditGame';
 import PlayerListItem from '../components/PlayerListItem';
+import SectionLabel from '../components/SectionLabel';
 import { MAX_PLAYERS } from '../constants';
 import { useTheme } from '../theme';
 
@@ -97,10 +98,10 @@ const EditGameScreen: React.FunctionComponent<Props> = ({ navigation, route }) =
     return (
         <View style={{ flex: 1 }} testID="edit-game">
 
-            <Text style={[styles.heading, { color: theme.textSecondary }]}>Game Title</Text>
+            <SectionLabel inset={30}>Game title</SectionLabel>
             <EditGame />
             <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                <Text style={[styles.heading, { color: theme.textSecondary }]}>Players</Text>
+                <SectionLabel inset={25}>Players</SectionLabel>
                 {playerIds.length > 1 &&
                     <TouchableOpacity onPress={() => {
                         setEdit(!edit);
@@ -109,7 +110,7 @@ const EditGameScreen: React.FunctionComponent<Props> = ({ navigation, route }) =
                             player_count: playerIds.length,
                         });
                     }}>
-                        <Text style={[styles.heading, { color: theme.tint }]}>{edit ? 'Done' : 'Edit'}</Text>
+                        <Text style={[styles.editAction, { color: theme.tint }]}>{edit ? 'Done' : 'Edit'}</Text>
                     </TouchableOpacity>
                 }
             </View>
@@ -159,11 +160,11 @@ const styles = StyleSheet.create({
         fontSize: 18,
         margin: 15,
     },
-    heading: {
-        fontSize: 14,
-        textTransform: 'uppercase',
+    editAction: {
+        fontSize: 13,
+        fontWeight: '600',
         marginHorizontal: 20,
-        marginVertical: 5,
+        marginBottom: 6,
         marginTop: 20,
     }
 });

--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -23,6 +23,7 @@ import { selectCurrentGame } from '../../redux/selectors';
 import { logEvent } from '../Analytics';
 import HeaderButton from '../components/Buttons/HeaderButton';
 import ColorSelector from '../components/ColorPalettes/ColorSelector';
+import SectionLabel from '../components/SectionLabel';
 import { useTheme } from '../theme';
 
 type RouteParams = {
@@ -31,6 +32,19 @@ type RouteParams = {
         playerId: string | undefined;
     };
 };
+
+/**
+ * Spelled-out player positions. MAX_PLAYERS is 20, so the list covers every
+ * position a game can have; the numeral fallback keeps the label sensible if
+ * that cap is ever raised.
+ */
+const NUMBER_WORDS = [
+    'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten',
+    'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen',
+    'eighteen', 'nineteen', 'twenty',
+];
+
+const playerPositionWord = (position: number) => NUMBER_WORDS[position - 1] ?? String(position);
 
 export interface EditPlayerScreenProps {
     navigation: NativeStackNavigationProp<ParamListBase, string, undefined>;
@@ -169,6 +183,8 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     return (
         <ScrollView style={{ flex: 1 }} keyboardShouldPersistTaps="handled">
 
+            <SectionLabel>{`Player ${playerPositionWord(index + 1)} name`}</SectionLabel>
+
             <View style={{ position: 'relative', zIndex: 1 }}>
                 <Input
                     ref={inputRef}
@@ -216,9 +232,7 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
                 )}
             </View>
 
-            <View style={{ marginHorizontal: 20 }}>
-                <ColorSelector playerId={playerId} />
-            </View>
+            <ColorSelector playerId={playerId} />
 
         </ScrollView>
     );


### PR DESCRIPTION
## What was there

| Label | Size | Weight | Case | Colour | Inset |
|---|---|---|---|---|---|
| `Current Pallete` / `Other Palletes` | 14 | 400 | Title Case | **`text`** | none |
| `Game Title` / `Players` | 14 | 400 | UPPERCASE | `textSecondary` | 20 |
| Settings sections | 12 | 400 | UPPERCASE | `textTertiary` | 40 |

Four treatments, three sizes, three colours, three casings. The palette headings used the *primary* text colour, so a section header rendered louder than the content it introduced — inverting the hierarchy.

## What it is now

A single `SectionLabel`: **13pt, weight 600, `theme.textSecondary`, sentence case**, with `accessibilityRole="header"`.

**Sentence case over uppercase.** Uppercase is the older Settings.app convention; SwiftUI's own list headers dropped it, and it reads badly on a field label — `PLAYER ONE NAME` is shouty for something that names a text box.

**Accessibility.** None of the old labels had `accessibilityRole="header"`, so VoiceOver couldn't navigate by section anywhere in the app. All five now do.

## Alignment

Each label takes the inset of the content beneath it, and those genuinely differ per screen:

| | Content inset | Why |
|---|---|---|
| Player name | 20 | RNE container 10 + inner container 10 |
| Palettes | 20 | swatch row pulled in to cancel the badge's 5pt margin |
| Game title | 30 | margin 10 + padding 10 + RNE container 10 |
| Players | 25 | row margin 10 + padding 10 + number padding 5 |
| Settings | 40 | card margin 20 + padding 20 |

`ColorSelector` now owns its inset instead of inheriting a `marginHorizontal: 20` wrapper from the screen. Its swatches carry a 5pt margin of their own, so inheriting put the whole palette section 5pt to the right of the name field above it.

## Also

- **Spelling**: `Pallete` → `palette`, `Palletes` → `palettes`.
- **`Edit`/`Done` on EditGameScreen** was borrowing `styles.heading`, so it rendered as `EDIT`. It's an action, not a heading — it has its own style now, since folding it into `SectionLabel` would announce a button as a heading.

## Not done here

The insets above still range from 20 to 40, so labels line up with their own content but not with each other across screens. Fixing that means normalising the *content* insets — the input containers, player rows and settings cards — which is a real layout change well beyond labels.

## Testing

`npm run lint` clean, 444 tests pass. Seven assertions updated for the new strings. JS-only — no rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)