### PR TITLE
fix(board): match the tile board's outer gutters to the gaps between tiles

### DIFF
--- a/src/components/Boards/PlayerTile.tsx
+++ b/src/components/Boards/PlayerTile.tsx
@@ -16,6 +16,8 @@ import AdditionTile from '../PlayerTiles/AdditionTile/AdditionTile';
 import PlayerIndexLabel from '../PlayerTiles/PlayerIndexLabel';
 import PlayerWinnerLabel from '../PlayerTiles/PlayerWinnerLabel';
 
+import { TILE_BORDER_WIDTH } from './layout';
+
 interface Props {
     index: number;
     playerId: string;
@@ -98,7 +100,7 @@ const PlayerTile: React.FunctionComponent<Props> = React.memo(({
 const styles = StyleSheet.create({
     playerCard: {
         borderRadius: 20,
-        borderWidth: 3,
+        borderWidth: TILE_BORDER_WIDTH,
         flexGrow: 1,
         justifyContent: 'center',
         alignItems: 'center',

--- a/src/components/Boards/TileBoard.test.tsx
+++ b/src/components/Boards/TileBoard.test.tsx
@@ -13,6 +13,7 @@ jest.mock('../Sheets/GameSheet', () => ({
     bottomSheetHeight: 80,
 }));
 
+import { TILE_BORDER_WIDTH } from './layout';
 import TileBoard from './TileBoard';
 
 // Mock react-native-safe-area-context
@@ -470,7 +471,10 @@ describe('TileBoard', () => {
         expect(safeAreaView.props.style).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
-                    paddingBottom: 82, // bottomSheetHeight (80) + 2
+                    // Every edge is padded by one tile border, so the gutter
+                    // against the sheet matches the gutter between tiles.
+                    padding: TILE_BORDER_WIDTH,
+                    paddingBottom: 82 + TILE_BORDER_WIDTH, // bottomSheetHeight (80) + 2
                 }),
             ])
         );

--- a/src/components/Boards/TileBoard.tsx
+++ b/src/components/Boards/TileBoard.tsx
@@ -8,6 +8,7 @@ import { useAppSelector } from '../../../redux/hooks';
 import { bottomSheetHeight } from '../../components/Sheets/GameSheet';
 import { useTheme } from '../../theme';
 
+import { TILE_BORDER_WIDTH } from './layout';
 import PlayerTile from './PlayerTile';
 
 const TileBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
@@ -90,7 +91,12 @@ const TileBoard: React.FC<{ showHint: boolean }> = ({ showHint }) => {
         <SafeAreaView edges={['left', 'right']} style={
             [styles.contentStyle,
             {
-                paddingBottom: fullscreen ? 20 : bottomSheetHeight + 2, // Add 2 to account for the border
+                // A tile contributes only one border at the board's edge, so the
+                // board adds the missing one. Every gutter — against the header,
+                // the sheet, the screen sides, and between tiles — then reads as
+                // TILE_BORDER_WIDTH * 2.
+                padding: TILE_BORDER_WIDTH,
+                paddingBottom: (fullscreen ? 20 : bottomSheetHeight + 2) + TILE_BORDER_WIDTH,
                 backgroundColor: theme.background,
             }]
         } onLayout={layoutHandler} >

--- a/src/components/Boards/layout.ts
+++ b/src/components/Boards/layout.ts
@@ -1,0 +1,9 @@
+/**
+ * Tiles have no margins — each draws a border in the board's background colour,
+ * so the gutter between two adjacent tiles is twice this.
+ *
+ * At the board's edge a tile contributes only one border, so TileBoard pads its
+ * own edges by the same amount. Every gutter then reads the same, whether it
+ * falls between two tiles or between a tile and the header, sheet or screen.
+ */
+export const TILE_BORDER_WIDTH = 3;


### PR DESCRIPTION
## The problem

The gaps between tiles aren't margins. Each tile draws `borderWidth: 3` in the board's background colour, so what you see between two adjacent tiles is **two** borders — 6pt. At the board's edge only one tile contributes, so the outer gutters were half that.

| | Before | After |
|---|---|---|
| Between tiles | 6 | 6 |
| Top (header) | 3 | 6 |
| Left / right | 3 | 6 |
| Bottom (sheet) | 5 | 6 |

The bottom was 5 rather than 3 because of a hand-added `+ 2` on `paddingBottom`, which is why the top gap looked visibly tighter than the bottom one.

## The fix

The board pads its own edges by one border width, supplying the border a tile can't. Every gutter then reads as `TILE_BORDER_WIDTH * 2`, and if that 3 ever changes, all four edges and the inter-tile gaps move together.

## Why the constant moved

It started as an export from `PlayerTile`, and `TileBoard.test.tsx` immediately failed with `padding: undefined` and `paddingBottom: NaN` — that suite mocks `./PlayerTile` wholesale, so the named export vanished.

That was worth listening to rather than working around: a gutter metric shared by the board and the tile isn't a `PlayerTile` implementation detail. It lives in `Boards/layout.ts` now and both import it.

## Not addressed here

`calculateTileDimensions` divides the **measured** height by `rows`, and `onLayout` reports the border box — which already includes the ~82pt of bottom padding reserved for the sheet. So the `maxWidth`/`maxHeight` hints passed to `AdditionTile` for font sizing have always overstated the real tile height, and this adds 6pt to that. Correcting it would visibly shrink the score fonts, so it wants its own change.

`ListBoard` (the dial layout) is untouched — it uses explicit 10pt padding and doesn't share the border trick, so its gutters won't match the tile board's.

## Testing

`npm run lint` clean, 444 tests pass. The `TileBoard` padding assertion now expresses itself in terms of the constant rather than a literal. JS-only — no rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)