### PR TITLE
fix(game-list): tidy the row's hierarchy, spacing and dates

### DIFF
--- a/src/components/GameListItem.test.tsx
+++ b/src/components/GameListItem.test.tsx
@@ -145,6 +145,92 @@ describe('GameListItem', () => {
         expect(getByText('Player 2')).toBeTruthy();
     });
 
+    it('should put winners first so a truncated player line still shows them', () => {
+        const store = createMockStore({
+            ...populatedState,
+            games: {
+                entities: {
+                    'game-1': {
+                        ...mockGame,
+                        playerIds: ['player-1', 'player-2', 'player-3'],
+                        winnerIds: ['player-3'],
+                    },
+                },
+                ids: ['game-1'],
+            },
+            players: {
+                entities: {
+                    ...mockPlayers,
+                    'player-3': { id: 'player-3', playerName: 'Player 3', scores: [20] },
+                },
+                ids: ['player-1', 'player-2', 'player-3'],
+            },
+        });
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+            </Provider>
+        );
+
+        // The names render as one Text, so assert the order of the elements
+        // that build it rather than hunting for separate text nodes.
+        const line = getByTestId('game-list-players');
+        const renderedIds = (line.props.children as { props: { playerId: string; }; }[])
+            .map(child => child.props.playerId);
+
+        expect(renderedIds).toEqual(['player-3', 'player-1', 'player-2']);
+    });
+
+    describe('created timestamp', () => {
+        const renderWithDate = (dateCreated: number) => {
+            const store = createMockStore({
+                ...populatedState,
+                games: {
+                    entities: { 'game-1': { ...mockGame, dateCreated } },
+                    ids: ['game-1'],
+                },
+            });
+
+            return render(
+                <Provider store={store}>
+                    <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+                </Provider>
+            );
+        };
+
+        it('stays relative under a day, where a date would only say today', () => {
+            const { getByText } = renderWithDate(Date.now() - 3 * 60 * 60 * 1000);
+
+            expect(getByText('3h ago')).toBeTruthy();
+        });
+
+        it('adds the weekday and date once it is days old', () => {
+            const threeDaysAgo = Date.now() - 3 * 86400000;
+            const { getByText } = renderWithDate(threeDaysAgo);
+
+            const expected = new Date(threeDaysAgo).toLocaleDateString(undefined, {
+                weekday: 'short', month: 'short', day: 'numeric',
+            });
+
+            expect(getByText(`3d ago · ${expected}`)).toBeTruthy();
+        });
+
+        it('trades the weekday for the year once out of this year', () => {
+            const date = new Date();
+            date.setFullYear(date.getFullYear() - 2);
+            const twoYearsAgo = date.getTime();
+
+            const { getByText } = renderWithDate(twoYearsAgo);
+
+            const expected = new Date(twoYearsAgo).toLocaleDateString(undefined, {
+                month: 'short', day: 'numeric', year: 'numeric',
+            });
+
+            expect(getByText(`2y ago · ${expected}`)).toBeTruthy();
+        });
+    });
+
     it('should show lock icon when game is locked', () => {
         const store = createMockStore({
             ...populatedState,

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -105,10 +105,10 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
     /**
      * Winners lead the player line.
      *
-     * That line is a single truncating line, and the result of a finished game
-     * is the last thing that should be cut from it — with the roster in play
-     * order a winner sitting fifth of six simply disappeared. Sorting is stable,
-     * so within each group the play order is kept.
+     * That line truncates, and the result of a finished game is the last thing
+     * that should be cut from it — with the roster in play order a winner far
+     * enough down simply disappeared. Sorting is stable, so within each group
+     * the play order is kept.
      */
     const orderedPlayerIds = useMemo(() => {
         const ids = playerIds ?? [];
@@ -158,9 +158,16 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
                                 {locked && <Icon name='lock-closed-outline' type='ionicon' size={14} color={theme.success} style={{ paddingHorizontal: 4 }} />}
                             </ListItem.Title>
 
-                            {/* One line of text, so the names wrap and truncate
-                              * together instead of each being its own block. */}
-                            <Text style={[styles.players, { color: theme.textSecondary }]} numberOfLines={1} testID="game-list-players">
+                            {/* One run of text, so the names wrap and truncate
+                              * together instead of each being its own block.
+                              *
+                              * Two lines rather than one: the column is ~29
+                              * characters wide, and players default to names as
+                              * long as "Player 1", so a single line cut an
+                              * ordinary three-player game short. Two covers past
+                              * the 91st percentile of player counts while still
+                              * keeping every row the same height. */}
+                            <Text style={[styles.players, { color: theme.textSecondary }]} numberOfLines={2} testID="game-list-players">
                                 {orderedPlayerIds.map((playerId, index) => (
                                     <GameListItemPlayerName key={playerId} playerId={playerId} last={index == orderedPlayerIds.length - 1} isWinner={winnerIds?.includes(playerId) === true} />
                                 ))}

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -16,8 +16,9 @@ import { useTheme } from '../theme';
 import GameListItemPlayerName from './GameListItemPlayerName';
 import AbstractPopupMenu from './PopupMenu/AbstractPopupMenu';
 
-function timeAgo(dateMs: number | undefined): string {
-    if (!dateMs) return '';
+const DAY_MS = 86400000;
+
+function timeAgo(dateMs: number): string {
     const diff = Date.now() - dateMs;
     const mins = Math.floor(diff / 60000);
     if (mins < 1) return 'just now';
@@ -29,6 +30,37 @@ function timeAgo(dateMs: number | undefined): string {
     const months = Math.floor(days / 30);
     if (months < 12) return `${months}mo ago`;
     return `${Math.floor(months / 12)}y ago`;
+}
+
+/**
+ * The calendar date behind a fuzzy one.
+ *
+ * Locale-formatted rather than hand-assembled, so the order of the parts
+ * follows the device. Within the current year the weekday earns its place and
+ * the year is redundant; further back that reverses.
+ */
+function shortDate(dateMs: number): string {
+    const date = new Date(dateMs);
+    const sameYear = date.getFullYear() === new Date().getFullYear();
+
+    return date.toLocaleDateString(undefined, sameYear
+        ? { weekday: 'short', month: 'short', day: 'numeric' }
+        : { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/**
+ * How long ago, plus the date once "3mo ago" stops being enough to place it.
+ *
+ * Under a day the relative form is already the precise one — appending a date
+ * there would only ever say today.
+ */
+function formatCreated(dateMs: number | undefined): string {
+    if (!dateMs) return '';
+
+    const relative = timeAgo(dateMs);
+    if (Date.now() - dateMs < DAY_MS) return relative;
+
+    return `${relative} · ${shortDate(dateMs)}`;
 }
 
 export type Props = {
@@ -70,6 +102,22 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
         dispatch(setCurrentGameId(gameId));
     }, [dispatch, gameId]);
 
+    /**
+     * Winners lead the player line.
+     *
+     * That line is a single truncating line, and the result of a finished game
+     * is the last thing that should be cut from it — with the roster in play
+     * order a winner sitting fifth of six simply disappeared. Sorting is stable,
+     * so within each group the play order is kept.
+     */
+    const orderedPlayerIds = useMemo(() => {
+        const ids = playerIds ?? [];
+        if (!winnerIds?.length) return ids;
+
+        return [...ids].sort((a, b) =>
+            Number(winnerIds.includes(b)) - Number(winnerIds.includes(a)));
+    }, [playerIds, winnerIds]);
+
     if (gameId == null) { return null; }
     if (gameTitle == null || roundCount == null || playerIds == null) { return null; }
 
@@ -99,32 +147,38 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
                 index={index}
                 onRender={onMenuRender}
             >
-                <ListItem bottomDivider testID="game-list-item"
+                <ListItem testID="game-list-item"
                     onPress={Platform.OS == 'android' ? undefined : chooseGameHandler}
-                    containerStyle={{ backgroundColor: theme.backgroundSecondary, borderBottomColor: theme.separator }}
+                    containerStyle={{ backgroundColor: theme.backgroundSecondary }}
                 >
-                    <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1, gap: 16 }}>
-                        <ListItem.Content style={{ flex: 1 }}>
-                            <ListItem.Title style={{ alignItems: 'center', color: theme.text }}>
+                    <View style={styles.row}>
+                        <ListItem.Content style={styles.content}>
+                            <ListItem.Title style={{ color: theme.text }}>
                                 {gameTitle}
                                 {locked && <Icon name='lock-closed-outline' type='ionicon' size={14} color={theme.success} style={{ paddingHorizontal: 4 }} />}
                             </ListItem.Title>
-                            <ListItem.Subtitle style={{ color: theme.textTertiary }}>
-                                <Text>{timeAgo(dateCreated)}</Text>
-                            </ListItem.Subtitle>
-                            <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-                                {playerIds.map((playerId, index) => (
-                                    <GameListItemPlayerName key={playerId} playerId={playerId} last={index == playerIds.length - 1} isWinner={winnerIds?.includes(playerId) === true} />
+
+                            {/* One line of text, so the names wrap and truncate
+                              * together instead of each being its own block. */}
+                            <Text style={[styles.players, { color: theme.textSecondary }]} numberOfLines={1} testID="game-list-players">
+                                {orderedPlayerIds.map((playerId, index) => (
+                                    <GameListItemPlayerName key={playerId} playerId={playerId} last={index == orderedPlayerIds.length - 1} isWinner={winnerIds?.includes(playerId) === true} />
                                 ))}
-                            </View>
+                            </Text>
+
+                            {/* Metadata trails the content it describes rather
+                              * than splitting the title from the players. */}
+                            <Text style={[styles.timestamp, { color: theme.textTertiary }]}>
+                                {formatCreated(dateCreated)}
+                            </Text>
                         </ListItem.Content>
-                        <Text style={[styles.badgePlayers, { color: theme.badgeBlue }]}>
-                            {playerIds.length} <Icon color={theme.badgeBlue} name='users' type='font-awesome-5' size={16} />
+                        <Text style={[styles.badge, { color: theme.badgeBlue }]}>
+                            {playerIds.length} <Icon color={theme.badgeBlue} name='users' type='font-awesome-5' size={13} />
                         </Text>
-                        <Text style={[styles.badgeRounds, { color: theme.badgeRed }]}>
-                            {roundCount} <Icon color={theme.badgeRed} name='circle-notch' type='font-awesome-5' size={16} />
+                        <Text style={[styles.badge, { color: theme.badgeRed }]}>
+                            {roundCount} <Icon color={theme.badgeRed} name='circle-notch' type='font-awesome-5' size={13} />
                         </Text>
-                        <ListItem.Chevron iconStyle={{ color: theme.separator }} />
+                        <ListItem.Chevron iconStyle={{ color: theme.textTertiary }} />
                     </View>
                 </ListItem>
             </AbstractPopupMenu>
@@ -133,19 +187,30 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
 };
 
 const styles = StyleSheet.create({
-    newGame: {
-        margin: 20,
-        width: 200,
-        alignSelf: 'center',
-    },
-    badgePlayers: {
+    row: {
+        flexDirection: 'row',
         alignItems: 'center',
-        fontSize: 20,
+        flex: 1,
+        gap: 14,
     },
-    badgeRounds: {
-        alignItems: 'center',
-        fontSize: 20,
-    }
+    content: {
+        flex: 1,
+        // Three text lines that were previously flush against each other.
+        gap: 3,
+    },
+    players: {
+        fontSize: 15,
+    },
+    timestamp: {
+        fontSize: 13,
+    },
+    /**
+     * Counts are the least important thing in the row. At 20pt they read before
+     * the game title; at 15 they sit with the secondary text where they belong.
+     */
+    badge: {
+        fontSize: 15,
+    },
 });
 
 export default memo(GameListItem);

--- a/src/components/GameListItemPlayerName.test.tsx
+++ b/src/components/GameListItemPlayerName.test.tsx
@@ -85,7 +85,7 @@ describe('GameListItemPlayerName', () => {
         expect(getByTestId('icon-trophy')).toBeTruthy();
     });
 
-    it('should apply bold styling when isWinner is true', () => {
+    it('should emphasise the name when isWinner is true', () => {
         const store = createMockStore({
             'player-1': { id: 'player-1', playerName: 'Alice', scores: [10] },
         });
@@ -96,26 +96,28 @@ describe('GameListItemPlayerName', () => {
             </Provider>
         );
 
-        const textElement = getByText('Alice, ');
+        // Matched loosely: the trophy is a sibling of the name inside the same
+        // Text so the names flow as one line, which splits the text content.
+        const textElement = getByText(/Alice/);
         expect(textElement.props.style).toEqual(
-            expect.arrayContaining([expect.objectContaining({ fontWeight: 'bold' })])
+            expect.arrayContaining([expect.objectContaining({ fontWeight: '600' })])
         );
     });
 
-    it('should apply default color when isWinner is false', () => {
+    it('should leave a non-winner unstyled so it inherits the row colour', () => {
         const store = createMockStore({
             'player-1': { id: 'player-1', playerName: 'Alice', scores: [10] },
         });
 
-        const { getByText } = render(
+        const { getByText, queryByTestId } = render(
             <Provider store={store}>
                 <GameListItemPlayerName playerId="player-1" isWinner={false} />
             </Provider>
         );
 
-        const textElement = getByText('Alice, ');
-        expect(textElement.props.style).toEqual(
-            expect.objectContaining({ color: expect.any(String) })
-        );
+        expect(queryByTestId('icon-trophy')).toBeNull();
+        // The colour belongs to the player line that wraps these, so a plain
+        // name deliberately carries no style of its own.
+        expect(getByText('Alice, ').props.style).toBeUndefined();
     });
 });

--- a/src/components/GameListItemPlayerName.tsx
+++ b/src/components/GameListItemPlayerName.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import { Icon } from 'react-native-elements';
 
 import { useAppSelector } from '../../redux/hooks';
@@ -11,33 +11,30 @@ interface Props {
     isWinner?: boolean;
 }
 
+/**
+ * One name in the game row's player line.
+ *
+ * Returns a nested `Text` rather than a `View`, so names flow and wrap as a
+ * single line of text and the parent can truncate the run of them. A winner
+ * used to render as a flex row, which made it a block among inline siblings —
+ * it sat off the baseline and broke where the line wrapped.
+ */
 const GameListItemPlayerName: React.FunctionComponent<Props> = ({ playerId, last = false, isWinner = false }) => {
     const theme = useTheme();
     const playerName = useAppSelector(state => selectPlayerById(state, playerId)?.playerName);
 
-    if (isWinner) {
-        return (
-            <View style={styles.winnerRow}>
-                <Icon name="trophy" type="ionicon" size={14} color={theme.warning} style={{ marginRight: 2 }} />
-                <Text style={[styles.winnerText, { color: theme.text }]}>
-                    {playerName}{!last && ', '}
-                </Text>
-            </View>
-        );
-    }
-
     return (
-        <Text style={{ color: theme.text }}>{playerName}{!last && ', '}</Text>
+        <Text style={isWinner ? [styles.winner, { color: theme.text }] : undefined}>
+            {isWinner && <Icon name="trophy" type="ionicon" size={13} color={theme.warning} />}
+            {isWinner && ' '}
+            {playerName}{!last && ', '}
+        </Text>
     );
 };
 
 const styles = StyleSheet.create({
-    winnerRow: {
-        flexDirection: 'row',
-        alignItems: 'center',
-    },
-    winnerText: {
-        fontWeight: 'bold',
+    winner: {
+        fontWeight: '600',
     },
 });
 

--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -4,7 +4,7 @@ import { useHeaderHeight } from '@react-navigation/elements';
 import { ParamListBase, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import * as Crypto from 'expo-crypto';
-import { Platform, StyleSheet, Text } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import Animated, { Easing, LinearTransition } from 'react-native-reanimated';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -89,6 +89,12 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                 contentInsetAdjustmentBehavior="never"
                 scrollIndicatorInsets={{ top: listHeaderInset, bottom: listBottomInset }}
                 itemLayoutAnimation={LinearTransition.easing(Easing.ease)}
+                ItemSeparatorComponent={() => (
+                    // Inset to the row's leading text rather than run edge to
+                    // edge, which is how iOS draws list separators. Lives on the
+                    // list so it is not drawn under the final row.
+                    <View style={[styles.separator, { backgroundColor: theme.separator }]} />
+                )}
                 ListEmptyComponent={
                     <>
                         <Text style={{ textAlign: 'center', padding: 30, paddingBottom: 10, fontSize: 16, fontWeight: 'bold', color: theme.text }}>No Games</Text>
@@ -110,6 +116,10 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
 
 const styles = StyleSheet.create({
     list: {
+    },
+    separator: {
+        height: StyleSheet.hairlineWidth,
+        marginLeft: 16,
     },
 });
 


### PR DESCRIPTION
## Before / after

```
Test Game                        2 👥  3 ↻   ›     Test Game  🔒                   2 👥 3 ↻  ›
2h ago                                       →     🏆 Carol, Alice, Bob
Alice, Bob                                         3d ago · Tue, Sep 3
```

## Hierarchy

**Metadata was splitting the content.** The row rendered title → `timeAgo` (tertiary grey) → players, so a timestamp sat between the title and the players that belong with it. Now it trails them.

**No vertical rhythm.** RNE gives `ListItem.Title` and `Subtitle` no margins, and the players row had none either — three text lines stacked flush. They now have a 3pt gap.

**The badges were the loudest thing in the row.** 20pt numerals in saturated blue and red against a 17pt title, for the least important information there. Down to 15pt, and the two byte-identical styles collapsed into one. Both also carried `alignItems: 'center'`, which does nothing on a `Text`.

## Player names now lay out as text

`GameListItemPlayerName` returned a `View` for winners and a bare `Text` otherwise, into a `flexWrap: 'wrap'` row — so they were flex *items*, not inline text. Winners sat off the baseline, spacing came only from the `', '` glued inside each string, and wrapping happened per block.

They're nested `Text` now, so the names flow, share a baseline, and truncate together under `numberOfLines={2}`. A 20-player game no longer towers over every other row.

**Two lines, not one.** The column is ~29 characters wide at 15pt, and players default to names as long as `Player 1` — so a single line was cutting ordinary three-player games short, not just the large ones. Checked against production data: 78% of games have four players or fewer and 91% have six or fewer, which two lines covers comfortably. Full wrapping stays off, since twenty players at ten characters a name is seven lines and that row would dwarf the rest of the list.

## Winners lead the line

Truncating introduced a problem worth calling out: **in play order, a winner far enough down the roster was cut off entirely.** For a list you scan for results, that's the wrong thing to lose, so winners now sort to the front. The sort is stable, so play order is kept within each group.

This does mean a finished game's roster no longer reads in strict play order. There's a regression test for the ordering — the row previously had **no winner assertions at all**, which is why nothing caught it.

## Dates

```
3h ago
3d ago · Tue, Sep 3
2y ago · Sep 3, 2024
```

Under 24 hours the relative form is already the precise one, so a date there would only ever say today. Beyond that it's appended. Within the current year the weekday earns its place and the year is redundant; further back that reverses. Locale-formatted via `toLocaleDateString` option objects rather than hand-assembled, so part order follows the device — the same approach `EditGame` already uses. `timeAgo` previously had no tests; all three branches are covered now.

## Native details

Type scale follows iOS — 17 title, 15 players, 13 timestamp, mapped to `textSecondary` / `textTertiary`. Winners are semibold rather than bold. The chevron moves from `theme.separator` to `theme.textTertiary`; it was tinted the same colour as a hairline rule, which made it nearly invisible.

The separator moves off the row (`bottomDivider`) onto the list as `ItemSeparatorComponent`, inset 16 to the content's leading edge — the iOS convention — and no longer drawn beneath the final row.

Dead code removed: unused `styles.newGame`, and a redundant `<Text>` nested inside `ListItem.Subtitle`.

## One thing left deliberately

The row still has no `onPress` on Android (`Platform.OS == 'android' ? undefined : ...`) and no `accessibilityRole` / `accessibilityLabel`. That looks deliberate — tapping is handled by the `AbstractPopupMenu` wrapper — but it means any accessibility work belongs on the wrapper, not the `ListItem`. Wanted your call before touching it.

## Testing

`npm run lint` clean, 448 tests pass. JS-only — no rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
