### PR TITLE
fix(list): refine game list hierarchy

### DIFF
--- a/src/components/GameListItem.test.tsx
+++ b/src/components/GameListItem.test.tsx
@@ -43,7 +43,7 @@ jest.mock('react-native-elements', () => {
         <TouchableOpacity testID={testID} onPress={onPress}>{children}</TouchableOpacity>
     );
     ListItem.Content = ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
-    ListItem.Title = ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>;
+    ListItem.Title = ({ children, style }: { children: React.ReactNode; style?: object }) => <Text style={style}>{children}</Text>;
     ListItem.Subtitle = ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>;
     ListItem.Chevron = () => <View testID="chevron" />;
 
@@ -143,6 +143,20 @@ describe('GameListItem', () => {
         expect(getByText('Test Game')).toBeTruthy();
         expect(getByText('Player 1, ')).toBeTruthy();
         expect(getByText('Player 2')).toBeTruthy();
+    });
+
+    it('should emphasize the game title', () => {
+        const store = createMockStore(populatedState);
+
+        const { getByText } = render(
+            <Provider store={store}>
+                <GameListItem navigation={mockNavigation} gameId="game-1" index={0} />
+            </Provider>
+        );
+
+        expect(getByText('Test Game').props.style).toEqual(
+            expect.arrayContaining([expect.objectContaining({ fontWeight: '600' })])
+        );
     });
 
     it('should put winners first so a truncated player line still shows them', () => {

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -153,7 +153,7 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
                 >
                     <View style={styles.row}>
                         <ListItem.Content style={styles.content}>
-                            <ListItem.Title style={{ color: theme.text }}>
+                            <ListItem.Title style={[styles.title, { color: theme.text }]}>
                                 {gameTitle}
                                 {locked && <Icon name='lock-closed-outline' type='ionicon' size={14} color={theme.success} style={{ paddingHorizontal: 4 }} />}
                             </ListItem.Title>
@@ -207,6 +207,9 @@ const styles = StyleSheet.create({
     },
     players: {
         fontSize: 15,
+    },
+    title: {
+        fontWeight: '600',
     },
     timestamp: {
         fontSize: 13,

--- a/src/components/GameListItemPlayerName.test.tsx
+++ b/src/components/GameListItemPlayerName.test.tsx
@@ -85,7 +85,7 @@ describe('GameListItemPlayerName', () => {
         expect(getByTestId('icon-trophy')).toBeTruthy();
     });
 
-    it('should emphasise the name when isWinner is true', () => {
+    it('should color the name when isWinner is true', () => {
         const store = createMockStore({
             'player-1': { id: 'player-1', playerName: 'Alice', scores: [10] },
         });
@@ -99,9 +99,7 @@ describe('GameListItemPlayerName', () => {
         // Matched loosely: the trophy is a sibling of the name inside the same
         // Text so the names flow as one line, which splits the text content.
         const textElement = getByText(/Alice/);
-        expect(textElement.props.style).toEqual(
-            expect.arrayContaining([expect.objectContaining({ fontWeight: '600' })])
-        );
+        expect(textElement.props.style).toEqual(expect.objectContaining({ color: '#000000' }));
     });
 
     it('should leave a non-winner unstyled so it inherits the row colour', () => {

--- a/src/components/GameListItemPlayerName.tsx
+++ b/src/components/GameListItemPlayerName.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text } from 'react-native';
+import { Text } from 'react-native';
 import { Icon } from 'react-native-elements';
 
 import { useAppSelector } from '../../redux/hooks';
@@ -24,18 +24,12 @@ const GameListItemPlayerName: React.FunctionComponent<Props> = ({ playerId, last
     const playerName = useAppSelector(state => selectPlayerById(state, playerId)?.playerName);
 
     return (
-        <Text style={isWinner ? [styles.winner, { color: theme.text }] : undefined}>
+        <Text style={isWinner ? { color: theme.text } : undefined}>
             {isWinner && <Icon name="trophy" type="ionicon" size={13} color={theme.warning} />}
             {isWinner && ' '}
             {playerName}{!last && ', '}
         </Text>
     );
 };
-
-const styles = StyleSheet.create({
-    winner: {
-        fontWeight: '600',
-    },
-});
 
 export default GameListItemPlayerName;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -51,7 +51,7 @@ const darkColors: ThemeColors = {
   backgroundSecondary: '#1C1C1E',
   backgroundTertiary: '#2C2C2E',
   text: '#FFFFFF',
-  textSecondary: '#EEEEEE',
+  textSecondary: '#AEAEB2',
   textTertiary: '#8E8E93',
   tint: '#0a84ff',
   separator: '#38383A',


### PR DESCRIPTION
## Summary
- make game list titles semibold for a Mail-like row hierarchy
- tune dark-mode secondary text so player names separate from titles
- keep winner emphasis to trophy and primary color instead of an extra font weight
- update list-row tests for the new title and winner styling

## Validation
- `npm test -- --runInBand`
- `npm run lint`
- `git diff --check`