### PR TITLE
fix(deps): bump expo ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.22.5",
-        "@expo/ui": "57.0.16",
+        "@expo/ui": "~57.0.17",
         "@expo/vector-icons": "^15.1.1",
         "@gorhom/bottom-sheet": "^5.2.14",
         "@quidone/react-native-wheel-picker": "^1.7.0",
@@ -3517,9 +3517,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/ui": {
-      "version": "57.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-57.0.16.tgz",
-      "integrity": "sha512-3MK74dEPE4mwlv0VbyQKepmHigOs2bcOvay2SFqc1/QSywVTOjbkNPYUbq2H+LyOLP2sHMazrPBwfXGiYn3q7A==",
+      "version": "57.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-57.0.17.tgz",
+      "integrity": "sha512-cnenUTsfX78i/EfXhA81Zv48sOxRdIq4YWCggwgBiPoOyS8J5CP/6dGyKo26ZVtcIsogWR4aXywaripeRF+6Ng==",
       "license": "MIT",
       "dependencies": {
         "sf-symbols-typescript": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.22.5",
-    "@expo/ui": "57.0.16",
+    "@expo/ui": "~57.0.17",
     "@expo/vector-icons": "^15.1.1",
     "@gorhom/bottom-sheet": "^5.2.14",
     "@quidone/react-native-wheel-picker": "^1.7.0",


### PR DESCRIPTION
## Summary
- bump @expo/ui from 57.0.16 to the 57.0.17 patch line
- update the lockfile to resolve @expo/ui 57.0.17

## Validation
- `node -e "console.log(require('./node_modules/@expo/ui/package.json').version); require.resolve('@expo/ui/swift-ui'); require.resolve('@expo/ui/swift-ui/modifiers'); console.log('resolved')"`
- `npm test -- FloatingActionButton.test.tsx --runInBand --coverage=false`
- `npm test -- --runInBand`
- `npm run lint`
- `git diff --check`