### PR TITLE
fix(list): repair game list separators and revert the android options button

### DIFF
--- a/src/components/Buttons/GameOptionsButton.tsx
+++ b/src/components/Buttons/GameOptionsButton.tsx
@@ -168,14 +168,30 @@ const GameOptionsButton: React.FunctionComponent = () => {
             testID="game-options-menu"
         >
             <View style={styles.button}>
-                {Platform.OS === 'android' ? (
-                    <View style={styles.androidOverflowButton}>
-                        <MaterialCommunityIcons name="dots-vertical" size={28} color={theme.text} />
+                <View style={styles.content}>
+                    <View style={styles.addendColumn}>
+                        <Text style={[styles.addendText, { color: theme.text }]}>{addendOne}</Text>
+                        <Text style={[styles.addendText, { color: theme.text }]}>{addendTwo}</Text>
+                    </View>
+                    <View>
+                        {Platform.OS === 'ios' ? (
+                            <SymbolView
+                                name={isDial ? 'dial.min' : isSwipe ? 'hand.draw' : 'hand.point.up'}
+                                size={30}
+                                tintColor={theme.text}
+                            />
+                        ) : (
+                            <MaterialCommunityIcons
+                                name={isDial ? 'knob' : isSwipe ? 'gesture-swipe-up' : 'gesture-tap'}
+                                size={30}
+                                color={theme.text}
+                            />
+                        )}
                         {showDialDot && (
                             <View testID="dial-notification-dot" style={{
                                 position: 'absolute',
-                                top: 6,
-                                right: 8,
+                                top: -2,
+                                right: -4,
                                 width: 8,
                                 height: 8,
                                 borderRadius: 4,
@@ -185,34 +201,7 @@ const GameOptionsButton: React.FunctionComponent = () => {
                             }} />
                         )}
                     </View>
-                ) : (
-                    <View style={styles.content}>
-                        <View style={styles.addendColumn}>
-                            <Text style={[styles.addendText, { color: theme.text }]}>{addendOne}</Text>
-                            <Text style={[styles.addendText, { color: theme.text }]}>{addendTwo}</Text>
-                        </View>
-                        <View>
-                            <SymbolView
-                                name={isDial ? 'dial.min' : isSwipe ? 'hand.draw' : 'hand.point.up'}
-                                size={30}
-                                tintColor={theme.text}
-                            />
-                            {showDialDot && (
-                                <View testID="dial-notification-dot" style={{
-                                    position: 'absolute',
-                                    top: -2,
-                                    right: -4,
-                                    width: 8,
-                                    height: 8,
-                                    borderRadius: 4,
-                                    backgroundColor: theme.warning,
-                                    borderWidth: 1,
-                                    borderColor: theme.backgroundSecondary,
-                                }} />
-                            )}
-                        </View>
-                    </View>
-                )}
+                </View>
             </View>
         </MenuView>
     );
@@ -220,13 +209,7 @@ const GameOptionsButton: React.FunctionComponent = () => {
 
 const styles = StyleSheet.create({
     button: {
-        padding: Platform.OS === 'android' ? 0 : 8,
-    },
-    androidOverflowButton: {
-        width: 48,
-        height: 48,
-        alignItems: 'center',
-        justifyContent: 'center',
+        padding: 8,
     },
     content: {
         flexDirection: 'row',

--- a/src/components/GameListItem.test.tsx
+++ b/src/components/GameListItem.test.tsx
@@ -7,9 +7,10 @@ import { act, fireEvent, render } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 import { Provider } from 'react-redux';
 
-import gamesReducer, { deleteGameAndPlayers, roundNext } from '../../redux/GamesSlice';
+import gamesReducer, { deleteGameAndPlayers, gameSave, roundNext } from '../../redux/GamesSlice';
 import playersReducer from '../../redux/PlayersSlice';
 import settingsReducer from '../../redux/SettingsSlice';
+import ListScreen from '../screens/ListScreen';
 
 import GameListItem from './GameListItem';
 
@@ -17,17 +18,48 @@ jest.mock('../Analytics', () => ({
     logEvent: jest.fn(),
 }));
 
+jest.mock('@react-navigation/elements', () => ({
+    useHeaderHeight: () => 0,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useFocusEffect: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+    SafeAreaView: jest.requireActual('react-native').View,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../hooks/useStoreReviewPrompt', () => ({
+    useStoreReviewPrompt: () => jest.fn(),
+}));
+
+jest.mock('./FloatingActionButton', () => ({
+    __esModule: true,
+    default: () => null,
+    FAB_BOTTOM_MARGIN: 16,
+    FAB_LIST_CLEARANCE: 16,
+    FAB_SIZE: 60,
+}));
+
 jest.mock('react-native-reanimated', () => {
-    const View = jest.requireActual('react-native').View;
+    const { FlatList, View } = jest.requireActual('react-native');
 
     return {
         __esModule: true,
         default: {
             View: View,
+            FlatList,
         },
         FadeInUp: {
             duration: jest.fn(() => ({ delay: jest.fn() })),
         },
+        LinearTransition: {
+            easing: jest.fn(() => ({})),
+        },
+        Easing: { ease: jest.fn() },
     };
 });
 
@@ -128,6 +160,48 @@ describe('GameListItem', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockContextMenuProps.current = null;
+    });
+
+    it('keeps separators between games as the mounted list gains and loses rows', () => {
+        const store = createMockStore(populatedState);
+        const { getByTestId, queryByTestId, queryAllByTestId, getByText } = render(
+            <Provider store={store}>
+                <ListScreen navigation={mockNavigation} />
+            </Provider>
+        );
+
+        expect(queryAllByTestId(/^game-list-separator-/)).toHaveLength(0);
+
+        // Prepend twice without remounting the screen, as creation/rematch do.
+        for (const number of [2, 3]) {
+            act(() => {
+                store.dispatch(gameSave({
+                    ...mockGame,
+                    id: `game-${number}`,
+                    title: `Game ${number}`,
+                    dateCreated: mockGame.dateCreated + number * 1000,
+                }));
+            });
+            expect(getByText(`Game ${number}`)).toBeTruthy();
+            // The newest game sorts to the top, so it draws no line of its own;
+            // the line belongs to the row it pushed down.
+            expect(queryByTestId(`game-list-separator-game-${number}`)).toBeNull();
+            expect(getByTestId('game-list-separator-game-1')).toBeTruthy();
+            expect(queryAllByTestId(/^game-list-separator-/)).toHaveLength(number - 1);
+        }
+
+        // Removing the trailing game must also remove the line above it.
+        act(() => {
+            store.dispatch(deleteGameAndPlayers('game-1'));
+        });
+        expect(queryByTestId('game-list-separator-game-1')).toBeNull();
+        expect(getByTestId('game-list-separator-game-2')).toBeTruthy();
+
+        act(() => {
+            store.dispatch(deleteGameAndPlayers('game-3'));
+        });
+        expect(getByText('Game 2')).toBeTruthy();
+        expect(queryAllByTestId(/^game-list-separator-/)).toHaveLength(0);
     });
 
     it('should render game title, players, and badges for a valid game', () => {

--- a/src/components/GameListItem.tsx
+++ b/src/components/GameListItem.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 
 import { ParamListBase } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Platform, StyleSheet, Text, View } from 'react-native';
+import { PixelRatio, Platform, StyleSheet, Text, View } from 'react-native';
 import { Icon, ListItem } from 'react-native-elements';
 import Animated, { FadeInUp } from 'react-native-reanimated';
 import { shallowEqual } from 'react-redux';
@@ -67,13 +67,14 @@ export type Props = {
     navigation: NativeStackNavigationProp<ParamListBase, string, undefined>;
     gameId: string;
     index: number;
+    showSeparator?: boolean;
     /** Test-only render probe for selector invalidation regressions. */
     onRender?: (id: string) => void;
     /** Test-only render probe for popup menu selector invalidation regressions. */
     onMenuRender?: (id: string) => void;
 };
 
-const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, index, onMenuRender, onRender }) => {
+const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, index, showSeparator = false, onMenuRender, onRender }) => {
     onRender?.(gameId);
 
     const theme = useTheme();
@@ -137,7 +138,10 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
     };
 
     return (
-        <Animated.View entering={FadeInUp.duration(200).delay(100 + index * 100)}>
+        <Animated.View collapsable={false} entering={FadeInUp.duration(200).delay(100 + index * 100)}>
+            {showSeparator && (
+                <View testID={`game-list-separator-${gameId}`} pointerEvents="none" style={[styles.separator, { backgroundColor: theme.separator }]} />
+            )}
             <AbstractPopupMenu
                 key={'menu' + gameId}
                 gameId={gameId}
@@ -200,6 +204,12 @@ const GameListItem: React.FunctionComponent<Props> = ({ navigation, gameId, inde
 };
 
 const styles = StyleSheet.create({
+    separator: {
+        marginLeft: 16,
+        flexShrink: 0,
+        // Android densities can be fractional: 1dp is not always a whole pixel.
+        height: PixelRatio.roundToNearestPixel(1),
+    },
     row: {
         flexDirection: 'row',
         alignItems: 'center',

--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -4,7 +4,7 @@ import { useHeaderHeight } from '@react-navigation/elements';
 import { ParamListBase, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import * as Crypto from 'expo-crypto';
-import { Platform, StyleSheet, Text, View } from 'react-native';
+import { Platform, Text } from 'react-native';
 import Animated, { Easing, LinearTransition } from 'react-native-reanimated';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -89,12 +89,6 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                 contentInsetAdjustmentBehavior="never"
                 scrollIndicatorInsets={{ top: listHeaderInset, bottom: listBottomInset }}
                 itemLayoutAnimation={LinearTransition.easing(Easing.ease)}
-                ItemSeparatorComponent={() => (
-                    // Inset to the row's leading text rather than run edge to
-                    // edge, which is how iOS draws list separators. Lives on the
-                    // list so it is not drawn under the final row.
-                    <View style={[styles.separator, { backgroundColor: theme.separator }]} />
-                )}
                 ListEmptyComponent={
                     <>
                         <Text style={{ textAlign: 'center', padding: 30, paddingBottom: 10, fontSize: 16, fontWeight: 'bold', color: theme.text }}>No Games</Text>
@@ -102,10 +96,10 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
                     </>
                 }
                 overScrollMode="always"
-                style={[styles.list, { backgroundColor: theme.backgroundSecondary }]}
+                style={{ backgroundColor: theme.backgroundSecondary }}
                 data={gameIds}
                 renderItem={({ item, index }) =>
-                    <GameListItem navigation={navigation} gameId={item as string} index={index} />
+                    <GameListItem navigation={navigation} gameId={item as string} index={index} showSeparator={index > 0} />
                 }
                 keyExtractor={item => item as string}
             >
@@ -114,14 +108,5 @@ const ListScreen: React.FunctionComponent<Props> = ({ navigation }) => {
         </SafeAreaView>
     );
 };
-
-const styles = StyleSheet.create({
-    list: {
-    },
-    separator: {
-        height: StyleSheet.hairlineWidth,
-        marginLeft: 16,
-    },
-});
 
 export default memo(ListScreen);


### PR DESCRIPTION
Two independent fixes to the game list and game header.

## Game list separators

`ItemSeparatorComponent` stopped keeping up with the list once `itemLayoutAnimation` was enabled. As rows animated into and out of an already-mounted list (game creation, rematch, delete), separators stayed attached to the wrong neighbours — lines went missing between games, and one lingered under the final row.

The line now lives on the row itself, rendered above every row but the first, so it moves with the row it belongs to. Two supporting details:

- Height is `PixelRatio.roundToNearestPixel(1)` rather than `StyleSheet.hairlineWidth`; fractional Android densities were rounding the hairline away to nothing.
- The row wrapper is `collapsable={false}` so Android's view flattening doesn't drop it.

Covered by a new test that drives a mounted `ListScreen` through prepends and deletes and asserts which rows own a line at each step.

## Android game options button

Reverts the `GameOptionsButton` portion of #755. That change swapped the shared layout for an android-only `dots-vertical` overflow glyph, which dropped the addend column and the current interaction-mode icon from the header on Android. Both platforms are back on the shared layout — the file is byte-identical to its pre-#755 state.

## Testing

- `npx jest` — 451 tests across 45 suites pass
- `npx tsc --noEmit` clean
- `npx eslint` on the changed files clean (one pre-existing `exhaustive-deps` warning in `ListScreen.tsx`, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)