### PR TITLE
fix(sheets): make the sheet edge visible on Android

### DIFF
--- a/src/components/Sheets/ChooseWinnersSheet.tsx
+++ b/src/components/Sheets/ChooseWinnersSheet.tsx
@@ -19,6 +19,7 @@ import { useTheme } from '../../theme';
 
 import { useChooseWinnersSheetContext } from './ChooseWinnersSheetContext';
 import GlassButton from './GlassButton';
+import SheetBackground from './SheetBackground';
 
 const ChooseWinnersSheet: React.FunctionComponent = () => {
     const theme = useTheme();
@@ -137,10 +138,9 @@ const ChooseWinnersSheet: React.FunctionComponent = () => {
             enablePanDownToClose={false}
             snapPoints={snapPoints}
             backdropComponent={renderBackdrop}
-            backgroundStyle={{ backgroundColor: theme.sheetBackground }}
+            backgroundComponent={SheetBackground}
             handleIndicatorStyle={{ backgroundColor: theme.sheetHandle }}
             topInset={topInset}
-            style={theme.background === '#000000' ? undefined : styles.sheetShadow}
             accessible={false}
             accessibilityViewIsModal={false}
         >
@@ -260,13 +260,6 @@ const styles = StyleSheet.create({
     playerScore: {
         fontSize: 16,
         fontWeight: '600',
-    },
-    sheetShadow: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: -3 },
-        shadowOpacity: 0.12,
-        shadowRadius: 5,
-        elevation: 8,
     },
 });
 

--- a/src/components/Sheets/GameSheet.tsx
+++ b/src/components/Sheets/GameSheet.tsx
@@ -19,6 +19,7 @@ import ScoreLogTable from '../ScoreLogTable';
 
 import { useChooseWinnersSheetContext } from './ChooseWinnersSheetContext';
 import { useGameSheetContext } from './GameSheetContext';
+import SheetBackground from './SheetBackground';
 
 /**
  * Height of the bottom sheet
@@ -249,13 +250,12 @@ const GameSheet: React.FunctionComponent = () => {
             onAnimate={onAnimate}
             snapPoints={snapPoints}
             backdropComponent={renderBackdrop}
-            backgroundStyle={{ backgroundColor: theme.sheetBackground }}
+            backgroundComponent={SheetBackground}
             handleComponent={renderHandle}
             handleIndicatorStyle={{ backgroundColor: theme.sheetHandle }}
             animatedPosition={animatedPosition}
             enablePanDownToClose={false}
             topInset={topInset}
-            style={theme.background === '#000000' ? undefined : styles.sheetShadow}
             accessible={false}
             accessibilityViewIsModal={false}
         >
@@ -393,13 +393,6 @@ const styles = StyleSheet.create({
         backgroundColor: 'rgba(0,0,0,.2)',
         borderRadius: 10,
         alignItems: 'center'
-    },
-    sheetShadow: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: -3 },
-        shadowOpacity: 0.12,
-        shadowRadius: 5,
-        elevation: 8,
     },
 });
 

--- a/src/components/Sheets/GestureInfoSheet.tsx
+++ b/src/components/Sheets/GestureInfoSheet.tsx
@@ -6,6 +6,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '../../theme';
 
 import { useGestureInfoSheetContext } from './GestureInfoSheetContext';
+import SheetBackground from './SheetBackground';
 
 const GestureInfoSheet: React.FunctionComponent = () => {
     const theme = useTheme();
@@ -32,7 +33,7 @@ const GestureInfoSheet: React.FunctionComponent = () => {
             enableDynamicSizing={false}
             enablePanDownToClose={true}
             backdropComponent={renderBackdrop}
-            backgroundStyle={{ backgroundColor: theme.sheetBackground }}
+            backgroundComponent={SheetBackground}
             handleIndicatorStyle={{ backgroundColor: theme.sheetHandle }}
         >
             <BottomSheetScrollView contentContainerStyle={styles.content} overScrollMode="always" style={styles.container}>

--- a/src/components/Sheets/PointValuesSheet.tsx
+++ b/src/components/Sheets/PointValuesSheet.tsx
@@ -18,6 +18,7 @@ import { useTheme } from '../../theme';
 import { InteractionType } from '../Interactions/InteractionType';
 
 import { usePointValuesSheetContext } from './PointValuesSheetContext';
+import SheetBackground from './SheetBackground';
 
 const ADDEND_OPTIONS = [...Array(100).keys()].map((index) => ({
     value: index + 1,
@@ -122,7 +123,7 @@ const PointValuesSheet: React.FunctionComponent = () => {
             snapPoints={snapPoints}
             onChange={handleSheetChanges}
             backdropComponent={renderBackdrop}
-            backgroundStyle={{ backgroundColor: theme.sheetBackground }}
+            backgroundComponent={SheetBackground}
             handleIndicatorStyle={{ backgroundColor: theme.sheetHandle }}>
             <BottomSheetScrollView
                 contentContainerStyle={{ alignItems: 'center' }}

--- a/src/components/Sheets/SheetBackground.tsx
+++ b/src/components/Sheets/SheetBackground.tsx
@@ -1,0 +1,69 @@
+import React, { memo } from 'react';
+
+import type { BottomSheetBackgroundProps } from '@gorhom/bottom-sheet';
+import { StyleSheet, View } from 'react-native';
+
+import { useTheme } from '../../theme';
+
+/**
+ * Radius used by the sheet surface. Matches the library default so swapping in
+ * this component does not change the silhouette.
+ */
+const SHEET_RADIUS = 15;
+
+/**
+ * Background for the bottom sheets.
+ *
+ * The library applies the `style` prop of `<BottomSheet>` to an outer,
+ * *transparent* container. Android derives an `elevation` shadow from the
+ * view's background outline, so an elevation on that transparent container is a
+ * no-op — which is why the iOS-only `shadow*`/`elevation` block never produced
+ * a shadow on Android. `elevation` is also not usable here even on the surface
+ * itself: it reorders siblings on the Z axis and would paint the background
+ * over the sheet's own content.
+ *
+ * Instead the surface itself is drawn here and separated from the board by:
+ *  - `boxShadow`, which paints without touching Z ordering and is supported on
+ *    both platforms under the New Architecture, and
+ *  - a hairline border, which renders deterministically everywhere.
+ *
+ * The border is what actually guarantees the fix: `boxShadow` is gated on API
+ * 28 on Android and silently does nothing below it, and even where it paints,
+ * an upward shadow reads as very faint against a light board. The board behind
+ * the collapsed sheet is `theme.background`, which is the same color as
+ * `theme.sheetBackground` in light mode, so without the border there is no
+ * contrast at all to fall back on.
+ */
+const SheetBackground: React.FunctionComponent<BottomSheetBackgroundProps> = ({ style, pointerEvents }) => {
+    const theme = useTheme();
+
+    return (
+        <View
+            pointerEvents={pointerEvents}
+            accessible={true}
+            accessibilityRole="adjustable"
+            accessibilityLabel="Bottom Sheet"
+            style={[
+                style,
+                styles.surface,
+                {
+                    backgroundColor: theme.sheetBackground,
+                    borderColor: theme.sheetBorder,
+                    boxShadow: `0px -3px 8px ${theme.sheetShadow}`,
+                },
+            ]}
+        />
+    );
+};
+
+const styles = StyleSheet.create({
+    surface: {
+        borderTopLeftRadius: SHEET_RADIUS,
+        borderTopRightRadius: SHEET_RADIUS,
+        // A full hairline border keeps the curve clean at the top corners; the
+        // left, right and bottom edges sit off-screen or flush to the bezel.
+        borderWidth: StyleSheet.hairlineWidth,
+    },
+});
+
+export default memo(SheetBackground);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,6 +12,8 @@ export interface ThemeColors {
   tint: string;
   separator: string;
   sheetBackground: string;
+  sheetBorder: string;
+  sheetShadow: string;
   sheetHandle: string;
   destructive: string;
   success: string;
@@ -34,6 +36,8 @@ const lightColors: ThemeColors = {
   tint: '#0a84ff',
   separator: '#C8C8CC',
   sheetBackground: '#F2F2F7',
+  sheetBorder: 'rgba(0,0,0,0.16)',
+  sheetShadow: 'rgba(0,0,0,0.14)',
   sheetHandle: '#D1D1D6',
   destructive: '#FF3B30',
   success: '#34C759',
@@ -56,6 +60,8 @@ const darkColors: ThemeColors = {
   tint: '#0a84ff',
   separator: '#38383A',
   sheetBackground: 'rgb(30,40,50)',
+  sheetBorder: 'rgba(255,255,255,0.14)',
+  sheetShadow: 'rgba(0,0,0,0.5)',
   sheetHandle: '#FFFFFF',
   destructive: '#FF453A',
   success: '#30D158',


### PR DESCRIPTION
## Summary

The game sheet had no visible boundary on Android. In light mode it blended completely into the board behind it — the handle was the only thing that gave it away.

<img width="900" height="166" alt="image" src="https://github.com/user-attachments/assets/c3b58977-0e01-4c8c-8b3e-76c7dc302f68" />
<img width="900" height="166" alt="image" src="https://github.com/user-attachments/assets/187f66c6-00b5-47f3-abe0-5bb5f9a5dfef" />


## Why the previous attempts couldn't work

Three things stack up, and fixing only one of them leaves the sheet invisible:

1. **The `elevation` was landing on a transparent view.** `<BottomSheet style={...}>` isn't applied to the sheet surface — the library forwards it to `BottomSheetBody`, a bare `Animated.View` with no background. Android derives an elevation shadow from the view's *background outline*, so no background means an empty outline and `elevation: 8` was a literal no-op. The iOS `shadow*` props on that same view did work, because iOS derives the shadow from layer contents instead.

2. **Moving `elevation` onto the surface would have broken the sheet.** It reorders siblings on the Z axis, so the background would paint over the handle and content.

3. **There was no color to fall back on.** `sheetBackground` and `background` are both `#F2F2F7` in light mode, and `TileBoard` paints `bottomSheetHeight + 2` of padding in exactly that color right behind the collapsed sheet. The shadow was doing 100% of the work of showing that a sheet existed.

## Changes

- New `SheetBackground` — a shared `backgroundComponent` that draws the surface itself, so the shadow has a real shape to come from.
- `boxShadow` instead of `elevation`: paint-only, no Z reordering, supported on both platforms under the New Architecture.
- A hairline border is what actually *guarantees* the fix. Outset `boxShadow` is gated at API 28 on Android and silently does nothing below it, and `minSdk` is Expo's default 24.
- New `sheetBorder` / `sheetShadow` theme tokens; the dead `sheetShadow` StyleSheet blocks are gone from `GameSheet` and `ChooseWinnersSheet`. All four sheets now share the one surface.

## Validation

Verified on a Pixel 10 emulator (API 37) through Fast Refresh, stashing and unstashing the change to compare the same frame region:

- light mode collapsed — the reported bug, and the fix
- expanded — content stacks correctly over the background, no Z-order regression
- dark mode, collapsed and expanded

`npx tsc --noEmit`, `npx eslint src/` (0 errors), `npx jest` (451 tests, 45 suites) all pass.

**iOS is unverified** — no simulator was booted and a build is slow, so this is reasoned rather than tested. The shadow moved from the transparent container onto the actual rounded surface, which should read near-identically or slightly crisper. Worst case if `boxShadow` disappoints there is a flatter shadow, not an invisible sheet, since the border still holds.

## Follow-up worth considering separately

`sheetBackground === background` in light mode is the root cause the shadow was papering over. Nudging the light sheet to something like `#EAEAEF` would give real tonal separation on every platform. Left alone here because it changes the iOS look and the white sub-elements inside the sheet (the Edit button, the ChooseWinners player list) are tuned against the current value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
