### PR TITLE
fix: polish Android navigation and launch behavior

### DIFF
--- a/docs/build-android.md
+++ b/docs/build-android.md
@@ -12,14 +12,23 @@
 ## Build Commands
 
 ```bash
-npm run android                          # Simulator/emulator (always local)
-APP_VARIANT=development npx expo run:android  # Dev variant
-APP_VARIANT=preview npx expo run:android      # Preview variant
+npm run android          # Production variant on the emulator (local)
+npm run android:dev      # Development client on the emulator (local)
+npm run android:preview  # Preview variant on the emulator (local)
 
 npx eas build --profile development --platform android   # Physical device
 npx eas build --profile preview --platform android       # Physical device
 npx eas build --profile production --platform android    # Store submission
 ```
+
+These local scripts regenerate the Android project, build and install the app, and
+open it on a connected device or an available emulator. Each script passes an
+explicit app ID so Android opens the correct variant when multiple ScorePad builds
+are installed and share the `exp+scorepad` development-client link.
+
+If emulator startup fails with `cannot write to emulator`, start the virtual device
+from Android Studio's Device Manager, wait for its home screen, then rerun
+`npm run android:dev`.
 
 ## Production Build Checklist
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
     "start": "expo start --dev-client",
-    "android": "npx expo prebuild --clean --platform android && expo run:android --variant release",
-    "android:dev": "APP_VARIANT=development npx expo prebuild --clean --platform android && APP_VARIANT=development expo run:android",
-    "android:preview": "APP_VARIANT=preview npx expo prebuild --clean --platform android && APP_VARIANT=preview expo run:android --variant release",
+    "android": "npx expo prebuild --clean --platform android && expo run:android --variant release --app-id com.wyne.scorepad",
+    "android:dev": "APP_VARIANT=development npx expo prebuild --clean --platform android && APP_VARIANT=development expo run:android --app-id com.wyne.scorepad.dev",
+    "android:preview": "APP_VARIANT=preview npx expo prebuild --clean --platform android && APP_VARIANT=preview expo run:android --variant release --app-id com.wyne.scorepad.preview",
     "prebuild": "npx expo prebuild",
     "prebuild:clean": "npx expo prebuild --clean",
     "ios": "npx expo prebuild --clean --platform ios && expo run:ios --configuration Release",

--- a/src/screens/EditGameScreen.tsx
+++ b/src/screens/EditGameScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect } from 'react';
 
 import { ParamListBase, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import DraggableFlatList, { ScaleDecorator } from 'react-native-draggable-flatlist';
 import { Button, Icon } from 'react-native-elements';
 
@@ -46,7 +46,7 @@ const EditGameScreen: React.FunctionComponent<Props> = ({ navigation, route }) =
     useLayoutEffect(() => {
         navigation.setOptions({
             headerRight: () => (
-                <HeaderButton accessibilityLabel='Save Game' onPress={() => {
+                <HeaderButton accessibilityLabel='Done' onPress={() => {
                     void logEvent('save_game', {
                         source: route?.params?.source,
                         game_id: currentGame?.id,
@@ -60,7 +60,10 @@ const EditGameScreen: React.FunctionComponent<Props> = ({ navigation, route }) =
                         navigation.goBack();
                     }
                 }}>
-                    <Text style={{ color: theme.tint, fontSize: 20 }} allowFontScaling={false}>Done</Text>
+                    {Platform.OS === 'android'
+                        ? <Icon name="check" color={theme.tint} size={28} />
+                        : <Text style={{ color: theme.tint, fontSize: 20 }} allowFontScaling={false}>Done</Text>
+                    }
                 </HeaderButton>
             ),
         });

--- a/src/screens/EditPlayerScreen.test.tsx
+++ b/src/screens/EditPlayerScreen.test.tsx
@@ -527,7 +527,7 @@ describe('EditPlayerScreen', () => {
         expect(store.getState().players.entities['player-1']?.playerName).toBe('Test Player');
     });
 
-    it('should dismiss the keyboard before navigating back', async () => {
+    it('should dismiss the keyboard when leaving the screen', () => {
         const dismissSpy = jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => undefined);
         const store = createMockStore({
             settings: {
@@ -560,15 +560,12 @@ describe('EditPlayerScreen', () => {
             </Provider>
         );
 
-        const options = mockNavigation.setOptions.mock.calls[0][0];
-        const backButton = options.headerLeft({ tintColor: '#fff' });
-
-        await act(async () => {
-            await backButton.props.onPress();
-        });
+        const beforeRemove = mockNavigation.addListener.mock.calls
+            .find((call: any[]) => call[0] === 'beforeRemove')?.[1];
+        act(() => beforeRemove?.());
 
         expect(dismissSpy).toHaveBeenCalled();
-        expect(mockNavigation.goBack).toHaveBeenCalled();
+        expect(Analytics.logEvent).toHaveBeenCalledWith('edit_player_back');
     });
 
     it('should limit input to 15 characters', () => {

--- a/src/screens/EditPlayerScreen.tsx
+++ b/src/screens/EditPlayerScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ParamListBase, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -21,7 +21,6 @@ import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { selectAllPlayerNames, updatePlayer } from '../../redux/PlayersSlice';
 import { selectCurrentGame } from '../../redux/selectors';
 import { logEvent } from '../Analytics';
-import HeaderButton from '../components/Buttons/HeaderButton';
 import ColorSelector from '../components/ColorPalettes/ColorSelector';
 import SectionLabel from '../components/SectionLabel';
 import { useTheme } from '../theme';
@@ -65,19 +64,6 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
         Keyboard.dismiss();
     }, []);
 
-    useLayoutEffect(() => {
-        navigation.setOptions({
-            headerLeft: ({ tintColor }) => (
-                <HeaderButton accessibilityLabel='EditPlayerBack' onPress={() => {
-                    dismissInput();
-                    navigation.goBack();
-                    void logEvent('edit_player_back');
-                }}>
-                    <Text style={{ color: tintColor ?? theme.tint, fontSize: 20 }}>Back</Text>
-                </HeaderButton>
-            ),
-        });
-    }, [dismissInput, navigation, theme.tint]);
     const dispatch = useAppDispatch();
     const currentGame = useAppSelector(selectCurrentGame);
     const { index, playerId } = route.params;
@@ -101,6 +87,7 @@ const EditPlayerScreen: React.FC<EditPlayerScreenProps> = ({
     useEffect(() => {
         const onBeforeRemove = () => {
             dismissInput();
+            void logEvent('edit_player_back');
             // Log a rename once per session, on any exit, if the name actually changed.
             if (latestNameRef.current !== originalPlayerName) {
                 logEvent('player_renamed', { game_id: currentGame?.id, player_index: index });


### PR DESCRIPTION
## Summary

- launch local Android builds with an explicit app ID so the requested ScorePad variant opens
- restore the native back arrow and spacing on Edit Player
- show a check icon for the Edit Game action on Android while retaining the Done label on iOS
- document the local Android commands and the emulator startup retry

## Validation

- `npm test -- --runInBand` — 45 suites, 451 tests passed
- ESLint and TypeScript checks passed
- verified Edit Game and Edit Player headers in the Android emulator
