### PR TITLE
feat: warn when editing earlier rounds

### DIFF
--- a/src/components/Headers/RoundHeaderTitle.tsx
+++ b/src/components/Headers/RoundHeaderTitle.tsx
@@ -72,24 +72,12 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
         </Text>
     ) : (
         <View style={styles.roundLabel}>
-            <View style={styles.roundDescriptorRow}>
-                <Text
-                    maxFontSizeMultiplier={1.15}
-                    style={[styles.roundDescriptor, { color: isEarlierRound ? theme.warning : theme.headerText }]}
-                >
-                    {roundDescriptor}
-                </Text>
-                {roundPickerEnabled && (
-                    <View style={styles.menuIndicator}>
-                        <Icon
-                            color={isEarlierRound ? theme.warning : theme.headerText}
-                            name="caret-down"
-                            size={7}
-                            type="font-awesome-5"
-                        />
-                    </View>
-                )}
-            </View>
+            <Text
+                maxFontSizeMultiplier={1.15}
+                style={[styles.roundDescriptor, { color: isEarlierRound ? theme.warning : theme.headerText }]}
+            >
+                {roundDescriptor}
+            </Text>
             <Text
                 maxFontSizeMultiplier={1.3}
                 style={[styles.roundValue, { color: theme.headerText }]}
@@ -250,11 +238,6 @@ const styles = StyleSheet.create({
         lineHeight: Platform.OS === 'android' ? 13 : 12,
         textAlign: 'center',
     },
-    roundDescriptorRow: {
-        alignItems: 'center',
-        flexDirection: 'row',
-        justifyContent: 'center',
-    },
     roundLabel: {
         alignItems: 'center',
         justifyContent: 'center',
@@ -270,10 +253,6 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         justifyContent: 'center',
         width: Platform.OS === 'android' ? 104 : 96,
-    },
-    menuIndicator: {
-        marginLeft: 4,
-        opacity: 0.55,
     },
     chevron: {
         width: Platform.OS === 'android' ? 44 : 40,

--- a/src/components/Headers/RoundHeaderTitle.tsx
+++ b/src/components/Headers/RoundHeaderTitle.tsx
@@ -57,10 +57,12 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
     };
 
     const isLocked = currentGame?.locked === true;
+    const isEarlierRound = !isLocked && currentRoundIndex < roundCount - 1;
     const previousDisabled = isLocked || isFirstRound;
     const nextDisabled = isLocked || isLastRound && (currentGame?.locked ?? false);
     const roundPickerEnabled = !isLocked && roundCount > 1;
-    const roundLabel = isLocked ? 'Final' : `Round ${currentRoundIndex + 1} of ${roundCount}`;
+    const roundDescriptor = isEarlierRound ? 'Earlier round' : 'Round';
+    const roundLabel = isLocked ? 'Final' : `${roundDescriptor} ${currentRoundIndex + 1} of ${roundCount}`;
     const roundPickerLabel = isLocked ? (
         <Text
             maxFontSizeMultiplier={1.3}
@@ -72,9 +74,9 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
         <View style={styles.roundLabel}>
             <Text
                 maxFontSizeMultiplier={1.15}
-                style={[styles.roundDescriptor, { color: theme.headerText }]}
+                style={[styles.roundDescriptor, { color: isEarlierRound ? theme.warning : theme.headerText }]}
             >
-                Round
+                {roundDescriptor}
             </Text>
             <Text
                 maxFontSizeMultiplier={1.3}
@@ -117,6 +119,7 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
             testID="round-picker-menu"
         >
             <View
+                accessibilityHint={isEarlierRound ? 'Score changes affect an earlier round' : undefined}
                 accessibilityLabel={`${roundLabel}. Select round`}
                 accessibilityRole="button"
                 style={styles.roundPicker}
@@ -179,7 +182,11 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
                 colorScheme={theme.headerText === '#FFFFFF' ? 'dark' : 'light'}
                 glassEffectStyle="regular"
                 isInteractive
-                style={styles.container}
+                style={[
+                    styles.container,
+                    styles.outlinedContainer,
+                    { borderColor: isEarlierRound ? theme.warning : 'transparent' },
+                ]}
             >
                 {controls}
             </GlassView>
@@ -192,7 +199,18 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
             ? 'rgba(255,255,255,0.14)'
             : 'rgba(118,118,128,0.12)';
 
-    return <View style={[styles.container, styles.fallbackContainer, { backgroundColor }]}>{controls}</View>;
+    return (
+        <View
+            style={[
+                styles.container,
+                styles.outlinedContainer,
+                styles.fallbackContainer,
+                { backgroundColor, borderColor: isEarlierRound ? theme.warning : 'transparent' },
+            ]}
+        >
+            {controls}
+        </View>
+    );
 };
 
 const styles = StyleSheet.create({
@@ -203,6 +221,9 @@ const styles = StyleSheet.create({
         borderRadius: Platform.OS === 'android' ? 24 : 22,
         height: Platform.OS === 'android' ? 48 : 44,
         width: Platform.OS === 'android' ? 192 : undefined,
+    },
+    outlinedContainer: {
+        borderWidth: Platform.OS === 'android' ? 2 : 1.5,
     },
     fallbackContainer: {
         overflow: 'hidden',

--- a/src/components/Headers/RoundHeaderTitle.tsx
+++ b/src/components/Headers/RoundHeaderTitle.tsx
@@ -72,12 +72,24 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
         </Text>
     ) : (
         <View style={styles.roundLabel}>
-            <Text
-                maxFontSizeMultiplier={1.15}
-                style={[styles.roundDescriptor, { color: isEarlierRound ? theme.warning : theme.headerText }]}
-            >
-                {roundDescriptor}
-            </Text>
+            <View style={styles.roundDescriptorRow}>
+                <Text
+                    maxFontSizeMultiplier={1.15}
+                    style={[styles.roundDescriptor, { color: isEarlierRound ? theme.warning : theme.headerText }]}
+                >
+                    {roundDescriptor}
+                </Text>
+                {roundPickerEnabled && (
+                    <View style={styles.menuIndicator}>
+                        <Icon
+                            color={isEarlierRound ? theme.warning : theme.headerText}
+                            name="caret-down"
+                            size={7}
+                            type="font-awesome-5"
+                        />
+                    </View>
+                )}
+            </View>
             <Text
                 maxFontSizeMultiplier={1.3}
                 style={[styles.roundValue, { color: theme.headerText }]}
@@ -125,9 +137,6 @@ const RoundHeaderTitle: React.FunctionComponent = () => {
                 style={styles.roundPicker}
             >
                 {roundPickerLabel}
-                <View style={styles.menuIndicator}>
-                    <Icon name="caret-down" type="font-awesome-5" size={9} color={theme.tint} />
-                </View>
             </View>
         </MenuView>
     ) : (
@@ -241,6 +250,11 @@ const styles = StyleSheet.create({
         lineHeight: Platform.OS === 'android' ? 13 : 12,
         textAlign: 'center',
     },
+    roundDescriptorRow: {
+        alignItems: 'center',
+        flexDirection: 'row',
+        justifyContent: 'center',
+    },
     roundLabel: {
         alignItems: 'center',
         justifyContent: 'center',
@@ -255,12 +269,11 @@ const styles = StyleSheet.create({
     roundPicker: {
         alignItems: 'center',
         justifyContent: 'center',
-        position: 'relative',
         width: Platform.OS === 'android' ? 104 : 96,
     },
     menuIndicator: {
-        position: 'absolute',
-        right: 5,
+        marginLeft: 4,
+        opacity: 0.55,
     },
     chevron: {
         width: Platform.OS === 'android' ? 44 : 40,


### PR DESCRIPTION
## Summary

- label non-latest rounds as "Earlier round"
- add an amber outline and label color to warn that score changes affect an earlier round
- keep the pill border geometry stable so Android preserves its contents when returning to the latest round
- keep the round descriptor visually centered without a dropdown caret while retaining its tap target
- add an accessibility hint describing the effect of editing an earlier round

## Validation

- verified latest → earlier → latest transitions in the Android emulator
- verified the latest-round appearance in the iOS simulator
- `npm run lint` (passes with existing warnings)
- `git diff --check`
