### PR TITLE
fix: enable Android release code obfuscation and resource shrinking

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -140,6 +140,10 @@ export default {
     [
       'expo-build-properties',
       {
+        android: {
+          enableMinifyInReleaseBuilds: true,
+          enableShrinkResourcesInReleaseBuilds: true,
+        },
         ios: {
           useFrameworks: 'static',
           forceStaticLinking: ['RNFBApp', 'RNFBAnalytics', 'RNFBCrashlytics'],


### PR DESCRIPTION
Google Play reports only 1% DEX obfuscation for release 3.2.0. Enable Android release minification through `expo-build-properties` so R8 can shrink and obfuscate native code, and enable unused-resource shrinking. These settings apply to release builds, including preview builds used for validation.

Validation: Expo config introspection confirms both generated Android Gradle properties are `true`; `git diff --check` passes. An Android release build and device smoke test are still needed before publishing, and the resulting Play optimization percentage has not been measured. The separate edge-to-edge dependency warning is not resolved by this change.
